### PR TITLE
chore(sync): mark story 1.1 done from merged PR #25

### DIFF
--- a/_bmad-output/implementation-artifacts/1-1-app-shell-design-system-display-name-onboarding.md
+++ b/_bmad-output/implementation-artifacts/1-1-app-shell-design-system-display-name-onboarding.md
@@ -1,6 +1,6 @@
 # Story 1.1: App Shell, Design System & Display Name Onboarding
 
-Status: review
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -4,7 +4,7 @@
 stories:
   "1.1":
     title: "App Shell, Design System & Display Name Onboarding"
-    status: review
+    status: done
     epic: 1
   "1.2":
     title: "iCloud Identity Association"


### PR DESCRIPTION
## Summary

- Synced story 1.1 (App Shell, Design System & Display Name Onboarding) status from `review` → `done`
- GitHub issue #1 was closed via merged PR #25
- Updated `sprint-status.yaml` and story file `1-1-app-shell-design-system-display-name-onboarding.md`
- Removed story worktree and cleaned up local branch

## Test plan
- [ ] Verify `sprint-status.yaml` shows `1.1: done`
- [ ] Verify story file `Status: done`
- [ ] Verify GitHub issue #1 has `status:done` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)