### PR TITLE
Story 3.2: Hole Card Tap Scoring & ScoreEvent Creation

### DIFF
--- a/HyzerApp.xcodeproj/project.pbxproj
+++ b/HyzerApp.xcodeproj/project.pbxproj
@@ -7,16 +7,20 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		079960697F1DB732A0FE5870 /* ScorecardContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4619B6CC10DE1F2616549B7E /* ScorecardContainerView.swift */; };
 		0F9A0D4BCB7C9197C852E4D5 /* CourseEditorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A20DA3AF53A4644D429F /* CourseEditorViewModelTests.swift */; };
 		1B216ACD7E371E7C974AA480 /* RoundSetupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B4334F9A1744E9A0EA28B0 /* RoundSetupViewModelTests.swift */; };
+		264848715C0438CE283A1429 /* ScorecardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0271AF96B676CB2280840B30 /* ScorecardViewModel.swift */; };
 		41CA9339A41BEC1B21B58E98 /* CourseEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902F00FF404EE9264C780629 /* CourseEditorView.swift */; };
 		43AA274D5D9454EBF1D658F2 /* AppServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DFB1F9AC07FE1B019DC349 /* AppServices.swift */; };
 		5105D60E9D7E55AB98453D0C /* CourseListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D567388ADB189B6F28DF15C2 /* CourseListView.swift */; };
 		5827D9E4DC7FC42B10CF812A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6A5193A54F5E0E9F5E5BA893 /* Assets.xcassets */; };
 		596A35E4701C525655211716 /* CourseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89EC7DCB75B63B758D964D2B /* CourseDetailView.swift */; };
 		602AE7FE552BCAAB9A145495 /* HyzerKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6AEC89D27BF2CC224C8D55BB /* HyzerKit */; };
+		6D665492C05385E1FB50E3B0 /* ScoreInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7876535734787458D7B0129 /* ScoreInputView.swift */; };
 		70D0955366D0881623788723 /* WatchRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65E7DE08C3408533CBAE374 /* WatchRootView.swift */; };
 		7291F41C97A3E4697FEBB72B /* ICloudIdentityResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD8964B40A6E0FDB412508C /* ICloudIdentityResolutionTests.swift */; };
+		806B440616278187DD30A471 /* ScorecardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB32460AB85326B67BFFE3 /* ScorecardViewModelTests.swift */; };
 		824CB3E7C4FE4793E135E5B0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800D115E8B8669538227512F /* ContentView.swift */; };
 		8C3A37E858EC8BF31CCE054B /* HyzerWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED517066535936D3C664FF33 /* HyzerWatchApp.swift */; };
 		93BDDE9BB3DD4F18A7A26E3F /* HyzerKit in Frameworks */ = {isa = PBXBuildFile; productRef = FBF7E3B49360BEFE78202833 /* HyzerKit */; };
@@ -26,6 +30,7 @@
 		A85DE61AD542BF166999182B /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975F8EB2A2D2513F584FD186 /* OnboardingView.swift */; };
 		A96BC87130D06BB117DA9903 /* OnboardingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A189F4C0A73BA714FD8BE50 /* OnboardingViewModelTests.swift */; };
 		AB7ECE958B351A749ED816BB /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EF3E5C7FF81BCA34D9DC08 /* OnboardingViewModel.swift */; };
+		AD08F59D9CCE35206B44FA22 /* HoleCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA34634C0B7110CFCB8DDC4 /* HoleCardView.swift */; };
 		BED316BD11BE024B8F9B7B12 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4814FA35A94A0628886B8CF5 /* Assets.xcassets */; };
 		D09FF1B7C7769F36982ED120 /* CourseEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253755A91DD162D3BE8524C6 /* CourseEditorViewModel.swift */; };
 		D2EF055D37B19C14B5DEF295 /* HyzerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC2A9F18AFB9B84DAD30F16 /* HyzerApp.swift */; };
@@ -66,6 +71,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0271AF96B676CB2280840B30 /* ScorecardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScorecardViewModel.swift; sourceTree = "<group>"; };
 		07943A8909080D9EEB547B64 /* HyzerKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = HyzerKit; path = HyzerKit; sourceTree = SOURCE_ROOT; };
 		0F654A8DF69B0F48A4399DA2 /* RoundSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundSetupViewModel.swift; sourceTree = "<group>"; };
 		1AFA4C5EA37270895D500678 /* HyzerWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HyzerWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -75,7 +81,9 @@
 		2CC2A9F18AFB9B84DAD30F16 /* HyzerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyzerApp.swift; sourceTree = "<group>"; };
 		39EF3E5C7FF81BCA34D9DC08 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		41F4A3FDA72AE73321E44E1B /* LiveICloudIdentityProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveICloudIdentityProvider.swift; sourceTree = "<group>"; };
+		4619B6CC10DE1F2616549B7E /* ScorecardContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScorecardContainerView.swift; sourceTree = "<group>"; };
 		4814FA35A94A0628886B8CF5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		54DB32460AB85326B67BFFE3 /* ScorecardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScorecardViewModelTests.swift; sourceTree = "<group>"; };
 		6A5193A54F5E0E9F5E5BA893 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		800D115E8B8669538227512F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		89EC7DCB75B63B758D964D2B /* CourseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailView.swift; sourceTree = "<group>"; };
@@ -84,6 +92,7 @@
 		9A189F4C0A73BA714FD8BE50 /* OnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		A0348F5FC211306493C34EDC /* HyzerApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HyzerApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5B4334F9A1744E9A0EA28B0 /* RoundSetupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundSetupViewModelTests.swift; sourceTree = "<group>"; };
+		BEA34634C0B7110CFCB8DDC4 /* HoleCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoleCardView.swift; sourceTree = "<group>"; };
 		C2DE096DC71267D6C2C700CD /* HyzerApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HyzerApp.entitlements; sourceTree = "<group>"; };
 		CB2045C0AF8BAAD5936DEC19 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		D4DFB1F9AC07FE1B019DC349 /* AppServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServices.swift; sourceTree = "<group>"; };
@@ -93,6 +102,7 @@
 		EE478A199AC62B27F4479A5D /* RoundSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundSetupView.swift; sourceTree = "<group>"; };
 		EE744D39F8F9982D7C7986DD /* HyzerWatch.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HyzerWatch.entitlements; sourceTree = "<group>"; };
 		F65E7DE08C3408533CBAE374 /* WatchRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchRootView.swift; sourceTree = "<group>"; };
+		F7876535734787458D7B0129 /* ScoreInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreInputView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,6 +139,7 @@
 				253755A91DD162D3BE8524C6 /* CourseEditorViewModel.swift */,
 				39EF3E5C7FF81BCA34D9DC08 /* OnboardingViewModel.swift */,
 				0F654A8DF69B0F48A4399DA2 /* RoundSetupViewModel.swift */,
+				0271AF96B676CB2280840B30 /* ScorecardViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -139,6 +150,7 @@
 				9550B01599FC7C965A2ED49F /* Courses */,
 				4058938EE2AEF93A9B8E92C9 /* Onboarding */,
 				A3C6B5A93C04D6F5020F06AF /* Rounds */,
+				BF769D23900DD74AB878F6B8 /* Scoring */,
 				800D115E8B8669538227512F /* ContentView.swift */,
 				CB2045C0AF8BAAD5936DEC19 /* HomeView.swift */,
 			);
@@ -203,6 +215,7 @@
 				2AD8964B40A6E0FDB412508C /* ICloudIdentityResolutionTests.swift */,
 				9A189F4C0A73BA714FD8BE50 /* OnboardingViewModelTests.swift */,
 				B5B4334F9A1744E9A0EA28B0 /* RoundSetupViewModelTests.swift */,
+				54DB32460AB85326B67BFFE3 /* ScorecardViewModelTests.swift */,
 			);
 			path = HyzerAppTests;
 			sourceTree = "<group>";
@@ -235,6 +248,16 @@
 				3F9EE8EAEFE2495CF3D31074 /* Views */,
 			);
 			path = HyzerApp;
+			sourceTree = "<group>";
+		};
+		BF769D23900DD74AB878F6B8 /* Scoring */ = {
+			isa = PBXGroup;
+			children = (
+				BEA34634C0B7110CFCB8DDC4 /* HoleCardView.swift */,
+				4619B6CC10DE1F2616549B7E /* ScorecardContainerView.swift */,
+				F7876535734787458D7B0129 /* ScoreInputView.swift */,
+			);
+			path = Scoring;
 			sourceTree = "<group>";
 		};
 		C04F9DE336288B8AE02E8295 /* HyzerWatch */ = {
@@ -434,6 +457,7 @@
 				7291F41C97A3E4697FEBB72B /* ICloudIdentityResolutionTests.swift in Sources */,
 				A96BC87130D06BB117DA9903 /* OnboardingViewModelTests.swift in Sources */,
 				1B216ACD7E371E7C974AA480 /* RoundSetupViewModelTests.swift in Sources */,
+				806B440616278187DD30A471 /* ScorecardViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -447,6 +471,7 @@
 				41CA9339A41BEC1B21B58E98 /* CourseEditorView.swift in Sources */,
 				D09FF1B7C7769F36982ED120 /* CourseEditorViewModel.swift in Sources */,
 				5105D60E9D7E55AB98453D0C /* CourseListView.swift in Sources */,
+				AD08F59D9CCE35206B44FA22 /* HoleCardView.swift in Sources */,
 				E7C9EB065EE96162F3722E3A /* HomeView.swift in Sources */,
 				D2EF055D37B19C14B5DEF295 /* HyzerApp.swift in Sources */,
 				A42D386C8B0A344A48653392 /* LiveICloudIdentityProvider.swift in Sources */,
@@ -454,6 +479,9 @@
 				AB7ECE958B351A749ED816BB /* OnboardingViewModel.swift in Sources */,
 				A74792297AFB13394CA53E4C /* RoundSetupView.swift in Sources */,
 				FA9AF7030053FC4206484C3D /* RoundSetupViewModel.swift in Sources */,
+				6D665492C05385E1FB50E3B0 /* ScoreInputView.swift in Sources */,
+				079960697F1DB732A0FE5870 /* ScorecardContainerView.swift in Sources */,
+				264848715C0438CE283A1429 /* ScorecardViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HyzerApp/App/AppServices.swift
+++ b/HyzerApp/App/AppServices.swift
@@ -1,5 +1,6 @@
 import SwiftData
 import Observation
+import UIKit
 import os.log
 import HyzerKit
 
@@ -11,6 +12,7 @@ import HyzerKit
 @Observable
 final class AppServices {
     let modelContainer: ModelContainer
+    let scoringService: ScoringService
     private(set) var iCloudRecordName: String?
 
     private let iCloudIdentityProvider: any ICloudIdentityProvider
@@ -19,6 +21,8 @@ final class AppServices {
 
     init(modelContainer: ModelContainer, iCloudIdentityProvider: any ICloudIdentityProvider) {
         self.modelContainer = modelContainer
+        let deviceID = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
+        self.scoringService = ScoringService(modelContext: modelContainer.mainContext, deviceID: deviceID)
         self.iCloudIdentityProvider = iCloudIdentityProvider
     }
 

--- a/HyzerApp/App/HyzerApp.swift
+++ b/HyzerApp/App/HyzerApp.swift
@@ -27,10 +27,10 @@ struct HyzerApp: App {
     // MARK: - Private
 
     private static func makeModelContainer() -> ModelContainer {
-        // Domain store: Player, Course, Hole, Round (and future: ScoreEvent) — synced via manual CloudKit
+        // Domain store: Player, Course, Hole, Round, ScoreEvent — synced via manual CloudKit
         let domainConfig = ModelConfiguration(
             "DomainStore",
-            schema: Schema([Player.self, Course.self, Hole.self, Round.self])
+            schema: Schema([Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self])
         )
         // Operational store: future SyncMetadata — local only, never syncs
         let operationalConfig = ModelConfiguration(
@@ -40,7 +40,7 @@ struct HyzerApp: App {
         )
         do {
             return try ModelContainer(
-                for: Player.self, Course.self, Hole.self, Round.self,
+                for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self,
                 configurations: domainConfig, operationalConfig
             )
         } catch {

--- a/HyzerApp/ViewModels/ScorecardViewModel.swift
+++ b/HyzerApp/ViewModels/ScorecardViewModel.swift
@@ -1,0 +1,38 @@
+import Foundation
+import HyzerKit
+
+/// Handles the score entry action for an active round.
+///
+/// Created in `ScorecardContainerView.onAppear` and owned by the view.
+/// Receives `ScoringService` via constructor injection (never `AppServices` container).
+@MainActor
+@Observable
+final class ScorecardViewModel {
+    private let scoringService: ScoringService
+    let roundID: UUID
+    let reportedByPlayerID: UUID
+
+    var saveError: Error?
+
+    init(scoringService: ScoringService, roundID: UUID, reportedByPlayerID: UUID) {
+        self.scoringService = scoringService
+        self.roundID = roundID
+        self.reportedByPlayerID = reportedByPlayerID
+    }
+
+    /// Records a score for a player on a specific hole.
+    ///
+    /// - Parameters:
+    ///   - playerID: Player.id.uuidString or "guest:{name}" for guests.
+    ///   - holeNumber: 1-based hole number.
+    ///   - strokeCount: The score (1-10).
+    func enterScore(playerID: String, holeNumber: Int, strokeCount: Int) throws {
+        try scoringService.createScoreEvent(
+            roundID: roundID,
+            holeNumber: holeNumber,
+            playerID: playerID,
+            strokeCount: strokeCount,
+            reportedByPlayerID: reportedByPlayerID
+        )
+    }
+}

--- a/HyzerApp/Views/HomeView.swift
+++ b/HyzerApp/Views/HomeView.swift
@@ -34,20 +34,13 @@ private struct ScoringTabView: View {
         sort: \Round.startedAt
     ) private var activeRounds: [Round]
 
-    @Query(sort: \Course.name) private var courses: [Course]
-    @Query(sort: \Player.displayName) private var allPlayers: [Player]
-
     @State private var isShowingRoundSetup = false
 
     var body: some View {
         NavigationStack {
             Group {
                 if let activeRound = activeRounds.first {
-                    ActiveRoundView(
-                        round: activeRound,
-                        courseName: courseName(for: activeRound),
-                        playerNames: playerNames(for: activeRound)
-                    )
+                    ScorecardContainerView(round: activeRound)
                 } else {
                     noRoundView
                 }
@@ -74,42 +67,6 @@ private struct ScoringTabView: View {
         }
     }
 
-    private func courseName(for round: Round) -> String {
-        courses.first { $0.id == round.courseID }?.name ?? "Unknown Course"
-    }
-
-    private func playerNames(for round: Round) -> [String] {
-        let registered = round.playerIDs.compactMap { playerID in
-            allPlayers.first { $0.id.uuidString == playerID }?.displayName
-        }
-        return registered + round.guestNames
-    }
-}
-
-// MARK: - Active Round (placeholder for Story 3.2)
-
-private struct ActiveRoundView: View {
-    let round: Round
-    let courseName: String
-    let playerNames: [String]
-
-    var body: some View {
-        VStack(spacing: SpacingTokens.lg) {
-            Text("Round at \(courseName)")
-                .font(TypographyTokens.h2)
-                .foregroundStyle(Color.textPrimary)
-            Text("\(round.holeCount) holes · \(playerNames.count) players")
-                .font(TypographyTokens.body)
-                .foregroundStyle(Color.textSecondary)
-            Text(playerNames.joined(separator: ", "))
-                .font(TypographyTokens.caption)
-                .foregroundStyle(Color.textSecondary)
-            Text("Scoring coming in Story 3.2")
-                .font(TypographyTokens.caption)
-                .foregroundStyle(Color.textSecondary)
-        }
-        .padding(SpacingTokens.xl)
-    }
 }
 
 // MARK: - History Tab (placeholder for Epic 8)

--- a/HyzerApp/Views/Scoring/HoleCardView.swift
+++ b/HyzerApp/Views/Scoring/HoleCardView.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+import HyzerKit
+
+/// A unified player row model combining registered players and guests.
+struct ScorecardPlayer: Identifiable {
+    /// Player.id.uuidString for registered players; "guest:{name}" for guests.
+    let id: String
+    let displayName: String
+    let isGuest: Bool
+}
+
+/// A single hole card showing hole info and all player score rows.
+///
+/// Displayed inside a `TabView(.page)` in `ScorecardContainerView`.
+/// Tapping an unscored player row expands an inline `ScoreInputView`.
+struct HoleCardView: View {
+    let holeNumber: Int
+    let par: Int
+    let courseName: String
+    let players: [ScorecardPlayer]
+    let scores: [ScoreEvent]
+    let onScore: (String, Int) -> Void
+
+    @State private var expandedPlayerID: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: SpacingTokens.md) {
+                holeHeader
+                Divider()
+                    .overlay(Color.backgroundTertiary)
+                playerRows
+            }
+            .padding(SpacingTokens.md)
+        }
+        .background(Color.backgroundElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .padding(.horizontal, SpacingTokens.md)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Hole \(holeNumber), Par \(par)")
+    }
+
+    // MARK: - Hole Header
+
+    private var holeHeader: some View {
+        VStack(spacing: SpacingTokens.xs) {
+            Text("Hole \(holeNumber)")
+                .font(TypographyTokens.h2)
+                .foregroundStyle(Color.textPrimary)
+            HStack(spacing: SpacingTokens.sm) {
+                Text("Par \(par)")
+                    .font(TypographyTokens.caption)
+                    .foregroundStyle(Color.textSecondary)
+                Text("·")
+                    .font(TypographyTokens.caption)
+                    .foregroundStyle(Color.textSecondary)
+                Text(courseName)
+                    .font(TypographyTokens.caption)
+                    .foregroundStyle(Color.textSecondary)
+            }
+        }
+        .padding(.top, SpacingTokens.sm)
+    }
+
+    // MARK: - Player Rows
+
+    private var playerRows: some View {
+        VStack(spacing: SpacingTokens.xs) {
+            ForEach(players) { player in
+                let currentScore = resolveCurrentScore(playerID: player.id)
+                if expandedPlayerID == player.id {
+                    ScoreInputView(
+                        playerName: player.displayName,
+                        par: par,
+                        onSelect: { strokeCount in
+                            onScore(player.id, strokeCount)
+                            expandedPlayerID = nil
+                        },
+                        onCancel: {
+                            expandedPlayerID = nil
+                        }
+                    )
+                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                } else {
+                    playerRow(player: player, score: currentScore)
+                }
+            }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: expandedPlayerID)
+    }
+
+    private func playerRow(player: ScorecardPlayer, score: ScoreEvent?) -> some View {
+        HStack {
+            Text(player.displayName)
+                .font(TypographyTokens.h3)
+                .foregroundStyle(Color.textPrimary)
+                .lineLimit(1)
+            Spacer()
+            if let score {
+                Text("\(score.strokeCount)")
+                    .font(TypographyTokens.score)
+                    .foregroundStyle(scoreColor(strokeCount: score.strokeCount, par: par))
+                    .accessibilityLabel("\(player.displayName), score \(score.strokeCount)")
+            } else {
+                Text("—")
+                    .font(TypographyTokens.score)
+                    .foregroundStyle(Color.textSecondary)
+                    .accessibilityLabel("\(player.displayName), no score")
+            }
+        }
+        .padding(.horizontal, SpacingTokens.md)
+        .frame(minHeight: SpacingTokens.minimumTouchTarget)
+        .background(Color.backgroundPrimary.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation {
+                expandedPlayerID = player.id
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+    }
+
+    // MARK: - Score Resolution (Amendment A7)
+
+    /// Returns the current (leaf node) ScoreEvent for a player on this hole.
+    ///
+    /// The current score is the ScoreEvent that no other ScoreEvent supersedes.
+    /// For Story 3.2, all events have `supersedesEventID = nil`, so every event is a leaf.
+    private func resolveCurrentScore(playerID: String) -> ScoreEvent? {
+        let playerScores = scores.filter { $0.playerID == playerID }
+        let supersededIDs = Set(playerScores.compactMap(\.supersedesEventID))
+        return playerScores.first { !supersededIDs.contains($0.id) }
+    }
+
+    // MARK: - Score Color
+
+    private func scoreColor(strokeCount: Int, par: Int) -> Color {
+        let diff = strokeCount - par
+        if diff <= -1 { return .scoreUnderPar }
+        if diff == 0  { return .scoreAtPar }
+        if diff == 1  { return .scoreOverPar }
+        return .scoreWayOver
+    }
+}

--- a/HyzerApp/Views/Scoring/HoleCardView.swift
+++ b/HyzerApp/Views/Scoring/HoleCardView.swift
@@ -21,6 +21,7 @@ struct HoleCardView: View {
     let scores: [ScoreEvent]
     let onScore: (String, Int) -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var expandedPlayerID: String?
 
     var body: some View {
@@ -86,7 +87,7 @@ struct HoleCardView: View {
                 }
             }
         }
-        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: expandedPlayerID)
+        .animation(AnimationCoordinator.animation(AnimationTokens.springStiff, reduceMotion: reduceMotion), value: expandedPlayerID)
     }
 
     private func playerRow(player: ScorecardPlayer, score: ScoreEvent?) -> some View {
@@ -114,7 +115,8 @@ struct HoleCardView: View {
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .contentShape(Rectangle())
         .onTapGesture {
-            withAnimation {
+            guard score == nil else { return }
+            withAnimation(AnimationCoordinator.animation(AnimationTokens.springStiff, reduceMotion: reduceMotion)) {
                 expandedPlayerID = player.id
             }
         }

--- a/HyzerApp/Views/Scoring/ScoreInputView.swift
+++ b/HyzerApp/Views/Scoring/ScoreInputView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+import UIKit
+import HyzerKit
+
+/// Inline score picker that expands within a player row.
+///
+/// Shows stroke values 1-10 in a horizontal row.
+/// The par value is visually highlighted as the anchor (FR18).
+/// Tapping a value fires haptic feedback, collapses the picker, and saves the score (FR17).
+/// Touch targets are at least `SpacingTokens.scoringTouchTarget` (52pt) per NFR14.
+struct ScoreInputView: View {
+    let playerName: String
+    let par: Int
+    let onSelect: (Int) -> Void
+    let onCancel: () -> Void
+
+    private let scores = Array(1...10)
+
+    var body: some View {
+        VStack(spacing: SpacingTokens.xs) {
+            HStack {
+                Text(playerName)
+                    .font(TypographyTokens.h3)
+                    .foregroundStyle(Color.textPrimary)
+                Spacer()
+                Button(action: onCancel) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(Color.textSecondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Cancel score entry")
+            }
+            .padding(.horizontal, SpacingTokens.md)
+
+            HStack(spacing: SpacingTokens.xs) {
+                ForEach(scores, id: \.self) { value in
+                    Button {
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        onSelect(value)
+                    } label: {
+                        Text("\(value)")
+                            .font(TypographyTokens.score)
+                            .foregroundStyle(value == par ? Color.backgroundPrimary : Color.textPrimary)
+                            .frame(
+                                minWidth: SpacingTokens.scoringTouchTarget,
+                                minHeight: SpacingTokens.scoringTouchTarget
+                            )
+                            .background(
+                                value == par
+                                    ? Color.accentPrimary
+                                    : Color.backgroundPrimary.opacity(0.6)
+                            )
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Score \(value)\(value == par ? ", par" : "")")
+                }
+            }
+            .padding(.horizontal, SpacingTokens.sm)
+        }
+        .padding(.vertical, SpacingTokens.sm)
+        .background(Color.backgroundElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Select score for \(playerName)")
+    }
+}

--- a/HyzerApp/Views/Scoring/ScoreInputView.swift
+++ b/HyzerApp/Views/Scoring/ScoreInputView.swift
@@ -15,6 +15,7 @@ struct ScoreInputView: View {
     let onCancel: () -> Void
 
     private let scores = Array(1...10)
+    private let haptic = UIImpactFeedbackGenerator(style: .light)
 
     var body: some View {
         VStack(spacing: SpacingTokens.xs) {
@@ -32,36 +33,47 @@ struct ScoreInputView: View {
             }
             .padding(.horizontal, SpacingTokens.md)
 
-            HStack(spacing: SpacingTokens.xs) {
-                ForEach(scores, id: \.self) { value in
-                    Button {
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                        onSelect(value)
-                    } label: {
-                        Text("\(value)")
-                            .font(TypographyTokens.score)
-                            .foregroundStyle(value == par ? Color.backgroundPrimary : Color.textPrimary)
-                            .frame(
-                                minWidth: SpacingTokens.scoringTouchTarget,
-                                minHeight: SpacingTokens.scoringTouchTarget
-                            )
-                            .background(
-                                value == par
-                                    ? Color.accentPrimary
-                                    : Color.backgroundPrimary.opacity(0.6)
-                            )
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: SpacingTokens.xs) {
+                    ForEach(scores, id: \.self) { value in
+                        Button {
+                            haptic.impactOccurred()
+                            onSelect(value)
+                        } label: {
+                            Text("\(value)")
+                                .font(TypographyTokens.score)
+                                .foregroundStyle(value == par ? Color.backgroundPrimary : Color.textPrimary)
+                                .frame(
+                                    minWidth: SpacingTokens.scoringTouchTarget,
+                                    minHeight: SpacingTokens.scoringTouchTarget
+                                )
+                                .background(
+                                    value == par
+                                        ? Color.accentPrimary
+                                        : Color.backgroundPrimary.opacity(0.6)
+                                )
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Score \(value)\(value == par ? ", par" : "")")
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Score \(value)\(value == par ? ", par" : "")")
                 }
+                .scrollTargetLayout()
+                .padding(.horizontal, SpacingTokens.sm)
             }
-            .padding(.horizontal, SpacingTokens.sm)
+            .defaultScrollAnchor(parScrollAnchor)
         }
         .padding(.vertical, SpacingTokens.sm)
         .background(Color.backgroundElevated)
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Select score for \(playerName)")
+        .onAppear { haptic.prepare() }
+    }
+
+    /// Scroll anchor that centers the par value in the visible area.
+    private var parScrollAnchor: UnitPoint {
+        let fraction = Double(par - 1) / Double(scores.count - 1)
+        return UnitPoint(x: fraction, y: 0.5)
     }
 }

--- a/HyzerApp/Views/Scoring/ScorecardContainerView.swift
+++ b/HyzerApp/Views/Scoring/ScorecardContainerView.swift
@@ -65,8 +65,8 @@ struct ScorecardContainerView: View {
         }
         .tabViewStyle(.page(indexDisplayMode: .automatic))
         .background(Color.backgroundPrimary)
-        .alert("Score Entry Error", isPresented: .constant(viewModel?.saveError != nil)) {
-            Button("OK") { viewModel?.saveError = nil }
+        .alert("Score Entry Error", isPresented: showingErrorBinding) {
+            Button("OK") { }
         } message: {
             Text(viewModel?.saveError?.localizedDescription ?? "")
         }
@@ -108,5 +108,12 @@ struct ScorecardContainerView: View {
 
     private var courseName: String {
         allCourses.first { $0.id == round.courseID }?.name ?? "Unknown Course"
+    }
+
+    private var showingErrorBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel?.saveError != nil },
+            set: { if !$0 { viewModel?.saveError = nil } }
+        )
     }
 }

--- a/HyzerAppTests/ScorecardViewModelTests.swift
+++ b/HyzerAppTests/ScorecardViewModelTests.swift
@@ -70,7 +70,7 @@ struct ScorecardViewModelTests {
     // MARK: - enterScore with different playerIDs creates separate events (distributed scoring)
 
     @Test("enterScore with different playerIDs creates separate events (distributed scoring)")
-    func test_enterScore_differentPlayerIDs_createsSeperateEvents() throws {
+    func test_enterScore_differentPlayerIDs_createsSeparateEvents() throws {
         let (context, service) = try makeContextAndService()
         let roundID = UUID()
 

--- a/HyzerAppTests/ScorecardViewModelTests.swift
+++ b/HyzerAppTests/ScorecardViewModelTests.swift
@@ -1,0 +1,94 @@
+import Testing
+import SwiftData
+import Foundation
+@testable import HyzerKit
+@testable import HyzerApp
+
+/// Tests for ScorecardViewModel (Story 3.2: hole card tap scoring).
+@Suite("ScorecardViewModel")
+@MainActor
+struct ScorecardViewModelTests {
+
+    // MARK: - Helper
+
+    private func makeContextAndService() throws -> (ModelContext, ScoringService) {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self,
+            configurations: config
+        )
+        let context = ModelContext(container)
+        let service = ScoringService(modelContext: context, deviceID: "vm-test-device")
+        return (context, service)
+    }
+
+    // MARK: - enterScore creates ScoreEvent via ScoringService
+
+    @Test("enterScore creates ScoreEvent via ScoringService")
+    func test_enterScore_createsScoreEvent() throws {
+        let (context, service) = try makeContextAndService()
+        let roundID = UUID()
+        let reporterID = UUID()
+
+        let vm = ScorecardViewModel(
+            scoringService: service,
+            roundID: roundID,
+            reportedByPlayerID: reporterID
+        )
+
+        try vm.enterScore(playerID: "player-abc", holeNumber: 5, strokeCount: 4)
+
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched.count == 1)
+        #expect(fetched[0].strokeCount == 4)
+        #expect(fetched[0].holeNumber == 5)
+        #expect(fetched[0].playerID == "player-abc")
+    }
+
+    // MARK: - enterScore passes correct roundID and reportedByPlayerID from init
+
+    @Test("enterScore passes correct roundID and reportedByPlayerID from init")
+    func test_enterScore_passesCorrectRoundIDAndReporterID() throws {
+        let (context, service) = try makeContextAndService()
+        let roundID = UUID()
+        let reporterID = UUID()
+
+        let vm = ScorecardViewModel(
+            scoringService: service,
+            roundID: roundID,
+            reportedByPlayerID: reporterID
+        )
+
+        try vm.enterScore(playerID: "player-xyz", holeNumber: 3, strokeCount: 3)
+
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched.count == 1)
+        #expect(fetched[0].roundID == roundID)
+        #expect(fetched[0].reportedByPlayerID == reporterID)
+    }
+
+    // MARK: - enterScore with different playerIDs creates separate events (distributed scoring)
+
+    @Test("enterScore with different playerIDs creates separate events (distributed scoring)")
+    func test_enterScore_differentPlayerIDs_createsSeperateEvents() throws {
+        let (context, service) = try makeContextAndService()
+        let roundID = UUID()
+
+        let vm = ScorecardViewModel(
+            scoringService: service,
+            roundID: roundID,
+            reportedByPlayerID: UUID()
+        )
+
+        try vm.enterScore(playerID: "player-one", holeNumber: 1, strokeCount: 3)
+        try vm.enterScore(playerID: "player-two", holeNumber: 1, strokeCount: 4)
+        try vm.enterScore(playerID: "guest:Dave", holeNumber: 1, strokeCount: 5)
+
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched.count == 3)
+        let playerIDs = Set(fetched.map(\.playerID))
+        #expect(playerIDs.contains("player-one"))
+        #expect(playerIDs.contains("player-two"))
+        #expect(playerIDs.contains("guest:Dave"))
+    }
+}

--- a/HyzerKit/Sources/HyzerKit/Domain/ScoringService.swift
+++ b/HyzerKit/Sources/HyzerKit/Domain/ScoringService.swift
@@ -35,6 +35,8 @@ public final class ScoringService {
         strokeCount: Int,
         reportedByPlayerID: UUID
     ) throws -> ScoreEvent {
+        precondition((1...10).contains(strokeCount), "strokeCount must be 1-10, got \(strokeCount)")
+        precondition(holeNumber >= 1, "holeNumber must be >= 1, got \(holeNumber)")
         let event = ScoreEvent(
             roundID: roundID,
             holeNumber: holeNumber,

--- a/HyzerKit/Sources/HyzerKit/Domain/ScoringService.swift
+++ b/HyzerKit/Sources/HyzerKit/Domain/ScoringService.swift
@@ -1,0 +1,50 @@
+import Foundation
+import SwiftData
+
+/// Creates immutable ScoreEvents in the domain SwiftData store.
+///
+/// Constructed by `AppServices` with the main ModelContext and device ID.
+/// All callers are `@MainActor`, so this is a plain class (not an actor).
+///
+/// Story 3.3 will add a correction flow that creates ScoreEvents with a non-nil
+/// `supersedesEventID`. For Story 3.2, all events have `supersedesEventID = nil`.
+public final class ScoringService {
+    private let modelContext: ModelContext
+    private let deviceID: String
+
+    public init(modelContext: ModelContext, deviceID: String) {
+        self.modelContext = modelContext
+        self.deviceID = deviceID
+    }
+
+    /// Creates an immutable ScoreEvent and persists it to the domain store.
+    ///
+    /// - Parameters:
+    ///   - roundID: The UUID of the round being scored.
+    ///   - holeNumber: 1-based hole number.
+    ///   - playerID: Player.id.uuidString or "guest:{name}" for guests.
+    ///   - strokeCount: The score (1-10).
+    ///   - reportedByPlayerID: The Player.id of whoever is entering this score.
+    /// - Returns: The created `ScoreEvent`.
+    /// - Throws: Rethrows any SwiftData persistence error. Never uses `try?`.
+    @discardableResult
+    public func createScoreEvent(
+        roundID: UUID,
+        holeNumber: Int,
+        playerID: String,
+        strokeCount: Int,
+        reportedByPlayerID: UUID
+    ) throws -> ScoreEvent {
+        let event = ScoreEvent(
+            roundID: roundID,
+            holeNumber: holeNumber,
+            playerID: playerID,
+            strokeCount: strokeCount,
+            reportedByPlayerID: reportedByPlayerID,
+            deviceID: deviceID
+        )
+        modelContext.insert(event)
+        try modelContext.save()
+        return event
+    }
+}

--- a/HyzerKit/Sources/HyzerKit/Models/ScoreEvent.swift
+++ b/HyzerKit/Sources/HyzerKit/Models/ScoreEvent.swift
@@ -1,0 +1,51 @@
+import Foundation
+import SwiftData
+
+/// An immutable score entry for one player on one hole of a round.
+///
+/// CloudKit compatibility constraints (same as Round):
+/// - No `@Attribute(.unique)` — CloudKit does not support unique constraints
+/// - All properties have defaults so CloudKit can instantiate without all values
+/// - No `@Relationship` — round and player referenced via flat foreign keys (Amendment A8)
+///
+/// Append-only invariant (NFR19): ScoreEvent has NO public update or delete API surface.
+/// The model is immutable after creation. Corrections create a new ScoreEvent with a
+/// non-nil `supersedesEventID` pointing to the replaced event (Story 3.3).
+///
+/// Guest players: `playerID` is a Player.id UUID string for registered players,
+/// or `"guest:{name}"` for guest players (e.g., `"guest:Dave"`).
+@Model
+public final class ScoreEvent {
+    public var id: UUID = UUID()
+    /// Flat FK to Round. Denormalized for CloudKit sync (Amendment A8).
+    public var roundID: UUID = UUID()
+    /// 1-based hole number.
+    public var holeNumber: Int = 1
+    /// Player.id.uuidString for registered players; "guest:{name}" for guests.
+    public var playerID: String = ""
+    /// The stroke count (1-10).
+    public var strokeCount: Int = 0
+    /// nil for initial scores; points to replaced event for corrections (Story 3.3).
+    public var supersedesEventID: UUID?
+    /// Player.id of whoever entered this score on their device.
+    public var reportedByPlayerID: UUID = UUID()
+    /// Originating device ID for conflict detection (Epic 4).
+    public var deviceID: String = ""
+    public var createdAt: Date = Date()
+
+    public init(
+        roundID: UUID,
+        holeNumber: Int,
+        playerID: String,
+        strokeCount: Int,
+        reportedByPlayerID: UUID,
+        deviceID: String
+    ) {
+        self.roundID = roundID
+        self.holeNumber = holeNumber
+        self.playerID = playerID
+        self.strokeCount = strokeCount
+        self.reportedByPlayerID = reportedByPlayerID
+        self.deviceID = deviceID
+    }
+}

--- a/HyzerKit/Tests/HyzerKitTests/Domain/ScoreEventModelTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/Domain/ScoreEventModelTests.swift
@@ -1,0 +1,151 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import HyzerKit
+
+@Suite("ScoreEvent model")
+struct ScoreEventModelTests {
+
+    // MARK: - Init creates ScoreEvent with correct properties and nil supersedesEventID
+
+    @Test("init creates ScoreEvent with correct properties and nil supersedesEventID")
+    func test_init_createsScoreEventWithCorrectProperties() {
+        let roundID = UUID()
+        let reporterID = UUID()
+
+        let event = ScoreEvent(
+            roundID: roundID,
+            holeNumber: 5,
+            playerID: "player-uuid-string",
+            strokeCount: 4,
+            reportedByPlayerID: reporterID,
+            deviceID: "device-123"
+        )
+
+        #expect(event.roundID == roundID)
+        #expect(event.holeNumber == 5)
+        #expect(event.playerID == "player-uuid-string")
+        #expect(event.strokeCount == 4)
+        #expect(event.reportedByPlayerID == reporterID)
+        #expect(event.deviceID == "device-123")
+        #expect(event.supersedesEventID == nil)
+        #expect(event.createdAt <= Date())
+        #expect(event.id != UUID(uuidString: "00000000-0000-0000-0000-000000000000"))
+    }
+
+    // MARK: - ScoreEvent persists and fetches in SwiftData (in-memory)
+
+    @Test("ScoreEvent persists and fetches correctly in SwiftData")
+    @MainActor
+    func test_scoreEvent_persistsAndFetches() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self,
+            configurations: config
+        )
+        let context = ModelContext(container)
+
+        let roundID = UUID()
+        let reporterID = UUID()
+        let event = ScoreEvent(
+            roundID: roundID,
+            holeNumber: 3,
+            playerID: "player-abc",
+            strokeCount: 2,
+            reportedByPlayerID: reporterID,
+            deviceID: "device-xyz"
+        )
+        context.insert(event)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched.count == 1)
+        #expect(fetched[0].roundID == roundID)
+        #expect(fetched[0].holeNumber == 3)
+        #expect(fetched[0].playerID == "player-abc")
+        #expect(fetched[0].strokeCount == 2)
+        #expect(fetched[0].reportedByPlayerID == reporterID)
+        #expect(fetched[0].deviceID == "device-xyz")
+        #expect(fetched[0].supersedesEventID == nil)
+    }
+
+    // MARK: - CloudKit compatibility — all properties have defaults
+
+    @Test("all properties have defaults for CloudKit compatibility")
+    func test_cloudKitCompatibility_allPropertiesHaveDefaults() {
+        let event = ScoreEvent(
+            roundID: UUID(),
+            holeNumber: 1,
+            playerID: "p",
+            strokeCount: 3,
+            reportedByPlayerID: UUID(),
+            deviceID: "d"
+        )
+        // All non-optional properties are populated after init
+        #expect(event.id != UUID(uuidString: "00000000-0000-0000-0000-000000000000"))
+        #expect(!event.playerID.isEmpty)
+        #expect(!event.deviceID.isEmpty)
+        // Optional property starts nil (OK for CloudKit)
+        #expect(event.supersedesEventID == nil)
+    }
+
+    // MARK: - Multiple ScoreEvents for same {round, hole, player} coexist (append-only)
+
+    @Test("multiple ScoreEvents for same round/hole/player all persist (append-only)")
+    @MainActor
+    func test_appendOnly_multipleEventsCoexist() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self,
+            configurations: config
+        )
+        let context = ModelContext(container)
+
+        let roundID = UUID()
+        let playerID = "player-123"
+
+        let event1 = ScoreEvent(roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 3,
+                                reportedByPlayerID: UUID(), deviceID: "d1")
+        let event2 = ScoreEvent(roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 4,
+                                reportedByPlayerID: UUID(), deviceID: "d2")
+        let event3 = ScoreEvent(roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 2,
+                                reportedByPlayerID: UUID(), deviceID: "d3")
+
+        context.insert(event1)
+        context.insert(event2)
+        context.insert(event3)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched.count == 3)
+    }
+
+    // MARK: - fixture helper
+
+    @Test("fixture() creates ScoreEvent with expected default values")
+    func test_fixture_createsScoreEventWithDefaults() {
+        let event = ScoreEvent.fixture()
+        #expect(event.holeNumber == 1)
+        #expect(event.strokeCount == 3)
+        #expect(event.deviceID == "test-device")
+        #expect(event.supersedesEventID == nil)
+    }
+
+    @Test("fixture() with custom values sets those values")
+    func test_fixture_withCustomValues_setsCorrectly() {
+        let roundID = UUID()
+        let playerID = "guest:Alice"
+        let event = ScoreEvent.fixture(
+            roundID: roundID,
+            holeNumber: 9,
+            playerID: playerID,
+            strokeCount: 5,
+            deviceID: "custom-device"
+        )
+        #expect(event.roundID == roundID)
+        #expect(event.holeNumber == 9)
+        #expect(event.playerID == "guest:Alice")
+        #expect(event.strokeCount == 5)
+        #expect(event.deviceID == "custom-device")
+    }
+}

--- a/HyzerKit/Tests/HyzerKitTests/Domain/ScoringServiceTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/Domain/ScoringServiceTests.swift
@@ -1,0 +1,139 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import HyzerKit
+
+@Suite("ScoringService")
+@MainActor
+struct ScoringServiceTests {
+
+    // MARK: - Helper
+
+    private func makeContext() throws -> (ModelContainer, ModelContext) {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self,
+            configurations: config
+        )
+        return (container, ModelContext(container))
+    }
+
+    // MARK: - createScoreEvent persists event with correct properties
+
+    @Test("createScoreEvent persists event with correct roundID, holeNumber, playerID, strokeCount")
+    func test_createScoreEvent_persistsCorrectProperties() throws {
+        let (_, context) = try makeContext()
+        let service = ScoringService(modelContext: context, deviceID: "test-device-1")
+
+        let roundID = UUID()
+        let reporterID = UUID()
+        let playerID = "player-uuid-abc"
+
+        let event = try service.createScoreEvent(
+            roundID: roundID,
+            holeNumber: 3,
+            playerID: playerID,
+            strokeCount: 4,
+            reportedByPlayerID: reporterID
+        )
+
+        #expect(event.roundID == roundID)
+        #expect(event.holeNumber == 3)
+        #expect(event.playerID == playerID)
+        #expect(event.strokeCount == 4)
+
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched.count == 1)
+        #expect(fetched[0].roundID == roundID)
+        #expect(fetched[0].holeNumber == 3)
+        #expect(fetched[0].playerID == playerID)
+        #expect(fetched[0].strokeCount == 4)
+    }
+
+    // MARK: - createScoreEvent sets reportedByPlayerID and deviceID correctly
+
+    @Test("createScoreEvent sets reportedByPlayerID and deviceID correctly")
+    func test_createScoreEvent_setsReporterAndDevice() throws {
+        let (_, context) = try makeContext()
+        let deviceID = "my-device-id-42"
+        let service = ScoringService(modelContext: context, deviceID: deviceID)
+
+        let reporterID = UUID()
+        let event = try service.createScoreEvent(
+            roundID: UUID(),
+            holeNumber: 1,
+            playerID: "player-x",
+            strokeCount: 3,
+            reportedByPlayerID: reporterID
+        )
+
+        #expect(event.reportedByPlayerID == reporterID)
+        #expect(event.deviceID == deviceID)
+
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched[0].reportedByPlayerID == reporterID)
+        #expect(fetched[0].deviceID == deviceID)
+    }
+
+    // MARK: - createScoreEvent sets supersedesEventID to nil
+
+    @Test("createScoreEvent sets supersedesEventID to nil")
+    func test_createScoreEvent_supersedesEventIDIsNil() throws {
+        let (_, context) = try makeContext()
+        let service = ScoringService(modelContext: context, deviceID: "d")
+
+        let event = try service.createScoreEvent(
+            roundID: UUID(),
+            holeNumber: 1,
+            playerID: "p",
+            strokeCount: 3,
+            reportedByPlayerID: UUID()
+        )
+
+        #expect(event.supersedesEventID == nil)
+
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched[0].supersedesEventID == nil)
+    }
+
+    // MARK: - createScoreEvent returns the created ScoreEvent
+
+    @Test("createScoreEvent returns the created ScoreEvent")
+    func test_createScoreEvent_returnsCreatedEvent() throws {
+        let (_, context) = try makeContext()
+        let service = ScoringService(modelContext: context, deviceID: "d")
+
+        let roundID = UUID()
+        let event = try service.createScoreEvent(
+            roundID: roundID,
+            holeNumber: 7,
+            playerID: "player-xyz",
+            strokeCount: 2,
+            reportedByPlayerID: UUID()
+        )
+
+        #expect(event.roundID == roundID)
+        #expect(event.holeNumber == 7)
+        #expect(event.strokeCount == 2)
+    }
+
+    // MARK: - Multiple events for same {round, hole, player} all persist (no uniqueness constraint)
+
+    @Test("multiple events for same round/hole/player all persist (no uniqueness constraint)")
+    func test_createScoreEvent_noUniquenessConstraint() throws {
+        let (_, context) = try makeContext()
+        let service = ScoringService(modelContext: context, deviceID: "d")
+
+        let roundID = UUID()
+        let playerID = "player-same"
+
+        try service.createScoreEvent(roundID: roundID, holeNumber: 2, playerID: playerID, strokeCount: 3, reportedByPlayerID: UUID())
+        try service.createScoreEvent(roundID: roundID, holeNumber: 2, playerID: playerID, strokeCount: 4, reportedByPlayerID: UUID())
+        try service.createScoreEvent(roundID: roundID, holeNumber: 2, playerID: playerID, strokeCount: 5, reportedByPlayerID: UUID())
+
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched.count == 3)
+        let strokeCounts = fetched.map(\.strokeCount).sorted()
+        #expect(strokeCounts == [3, 4, 5])
+    }
+}

--- a/HyzerKit/Tests/HyzerKitTests/Fixtures/ScoreEvent+Fixture.swift
+++ b/HyzerKit/Tests/HyzerKitTests/Fixtures/ScoreEvent+Fixture.swift
@@ -1,0 +1,23 @@
+import Foundation
+@testable import HyzerKit
+
+public extension ScoreEvent {
+    /// Creates a ScoreEvent with test defaults. Use in tests only.
+    static func fixture(
+        roundID: UUID = UUID(),
+        holeNumber: Int = 1,
+        playerID: String = UUID().uuidString,
+        strokeCount: Int = 3,
+        reportedByPlayerID: UUID = UUID(),
+        deviceID: String = "test-device"
+    ) -> ScoreEvent {
+        ScoreEvent(
+            roundID: roundID,
+            holeNumber: holeNumber,
+            playerID: playerID,
+            strokeCount: strokeCount,
+            reportedByPlayerID: reportedByPlayerID,
+            deviceID: deviceID
+        )
+    }
+}

--- a/_bmad-output/implementation-artifacts/3-2-hole-card-tap-scoring-and-scoreevent-creation.md
+++ b/_bmad-output/implementation-artifacts/3-2-hole-card-tap-scoring-and-scoreevent-creation.md
@@ -542,18 +542,34 @@ claude-sonnet-4-6
 - HyzerKit tests (35/35 pass). iOS simulator tests blocked by pre-existing iOS 26 + SwiftData + AppGroup incompatibility (same as all prior stories — not a code issue).
 - SwiftLint: no errors or warnings.
 
+### Senior Developer Review (AI)
+
+**Reviewer:** claude-opus-4-6 | **Date:** 2026-02-27
+
+**Result: PASSED** (7 findings, all resolved)
+
+| # | Severity | Finding | Resolution |
+|---|----------|---------|------------|
+| H1 | HIGH | Scored rows tappable — allows re-scoring without supersession chain (Story 3.3 scope leak) | Added `guard score == nil` in `onTapGesture` to disable tap on scored rows |
+| H2 | HIGH | ScoreInputView 10×52pt buttons overflow on all iPhones (NFR14 violation) | Wrapped HStack in horizontal `ScrollView` with `defaultScrollAnchor` centered on par |
+| M1 | MEDIUM | Alert binding uses `.constant()` — non-writable, may not dismiss | Replaced with computed `Binding` via `showingErrorBinding` property |
+| M2 | MEDIUM | Hardcoded `.spring()` animation instead of `AnimationTokens`/`AnimationCoordinator` | Switched to `AnimationCoordinator.animation(AnimationTokens.springStiff, reduceMotion:)` with `@Environment(\.accessibilityReduceMotion)` |
+| M3 | MEDIUM | Missing `precondition` for strokeCount range (1-10) in `ScoringService` | Added `precondition((1...10).contains(strokeCount))` and `precondition(holeNumber >= 1)` |
+| L1 | LOW | `UIImpactFeedbackGenerator` instantiated per tap | Moved to stored property with `.onAppear { haptic.prepare() }` |
+| L2 | LOW | Typo: `createsSeperateEvents` → `createsSeparateEvents` | Fixed method name |
+
 ### File List
 
 - `HyzerKit/Sources/HyzerKit/Models/ScoreEvent.swift` — created
-- `HyzerKit/Sources/HyzerKit/Domain/ScoringService.swift` — created
+- `HyzerKit/Sources/HyzerKit/Domain/ScoringService.swift` — created (review: added preconditions)
 - `HyzerApp/App/HyzerApp.swift` — modified (added ScoreEvent to ModelContainer)
 - `HyzerApp/App/AppServices.swift` — modified (added scoringService, UIKit import)
 - `HyzerApp/ViewModels/ScorecardViewModel.swift` — created
-- `HyzerApp/Views/Scoring/ScorecardContainerView.swift` — created
-- `HyzerApp/Views/Scoring/HoleCardView.swift` — created
-- `HyzerApp/Views/Scoring/ScoreInputView.swift` — created
+- `HyzerApp/Views/Scoring/ScorecardContainerView.swift` — created (review: fixed alert binding)
+- `HyzerApp/Views/Scoring/HoleCardView.swift` — created (review: disabled scored-row tap, AnimationTokens, reduce-motion)
+- `HyzerApp/Views/Scoring/ScoreInputView.swift` — created (review: ScrollView wrapper, haptic prepare, scroll anchor)
 - `HyzerApp/Views/HomeView.swift` — modified (replaced ActiveRoundView with ScorecardContainerView, removed unused code)
 - `HyzerKit/Tests/HyzerKitTests/Fixtures/ScoreEvent+Fixture.swift` — created
 - `HyzerKit/Tests/HyzerKitTests/Domain/ScoreEventModelTests.swift` — created
 - `HyzerKit/Tests/HyzerKitTests/Domain/ScoringServiceTests.swift` — created
-- `HyzerAppTests/ScorecardViewModelTests.swift` — created
+- `HyzerAppTests/ScorecardViewModelTests.swift` — created (review: fixed typo)

--- a/_bmad-output/implementation-artifacts/3-2-hole-card-tap-scoring-and-scoreevent-creation.md
+++ b/_bmad-output/implementation-artifacts/3-2-hole-card-tap-scoring-and-scoreevent-creation.md
@@ -1,6 +1,6 @@
 # Story 3.2: Hole Card Tap Scoring & ScoreEvent Creation
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -46,84 +46,84 @@ So that I can record scores quickly and accurately during a round.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create `ScoreEvent` SwiftData model in HyzerKit (AC: 2, 6)
-  - [ ] 1.1 Create `HyzerKit/Sources/HyzerKit/Models/ScoreEvent.swift` with `@Model` class
-  - [ ] 1.2 Properties: `id`, `roundID`, `holeNumber`, `playerID` (String), `strokeCount`, `supersedesEventID` (UUID?), `reportedByPlayerID`, `deviceID` (String), `createdAt`
-  - [ ] 1.3 CloudKit constraints: all properties have defaults, no `@Attribute(.unique)`, no `@Relationship`
-  - [ ] 1.4 NO public update or delete API surface (type-level invariant for NFR19 append-only)
-  - [ ] 1.5 Init accepts `roundID`, `holeNumber`, `playerID`, `strokeCount`, `reportedByPlayerID`, `deviceID`
+- [x] Task 1: Create `ScoreEvent` SwiftData model in HyzerKit (AC: 2, 6)
+  - [x] 1.1 Create `HyzerKit/Sources/HyzerKit/Models/ScoreEvent.swift` with `@Model` class
+  - [x] 1.2 Properties: `id`, `roundID`, `holeNumber`, `playerID` (String), `strokeCount`, `supersedesEventID` (UUID?), `reportedByPlayerID`, `deviceID` (String), `createdAt`
+  - [x] 1.3 CloudKit constraints: all properties have defaults, no `@Attribute(.unique)`, no `@Relationship`
+  - [x] 1.4 NO public update or delete API surface (type-level invariant for NFR19 append-only)
+  - [x] 1.5 Init accepts `roundID`, `holeNumber`, `playerID`, `strokeCount`, `reportedByPlayerID`, `deviceID`
 
-- [ ] Task 2: Register `ScoreEvent` in ModelContainer (AC: 2)
-  - [ ] 2.1 Add `ScoreEvent.self` to `Schema` and `ModelContainer(for:)` in `HyzerApp.swift`
+- [x] Task 2: Register `ScoreEvent` in ModelContainer (AC: 2)
+  - [x] 2.1 Add `ScoreEvent.self` to `Schema` and `ModelContainer(for:)` in `HyzerApp.swift`
 
-- [ ] Task 3: Create `ScoringService` in HyzerKit (AC: 2)
-  - [ ] 3.1 Create `HyzerKit/Sources/HyzerKit/Domain/ScoringService.swift`
-  - [ ] 3.2 Constructor: `init(modelContext: ModelContext, deviceID: String)`
-  - [ ] 3.3 Method: `createScoreEvent(roundID:holeNumber:playerID:strokeCount:reportedByPlayerID:) throws -> ScoreEvent`
-  - [ ] 3.4 Creates ScoreEvent with `supersedesEventID: nil` (corrections are Story 3.3)
-  - [ ] 3.5 Inserts into modelContext and saves; throws on failure (never `try?`)
+- [x] Task 3: Create `ScoringService` in HyzerKit (AC: 2)
+  - [x] 3.1 Create `HyzerKit/Sources/HyzerKit/Domain/ScoringService.swift`
+  - [x] 3.2 Constructor: `init(modelContext: ModelContext, deviceID: String)`
+  - [x] 3.3 Method: `createScoreEvent(roundID:holeNumber:playerID:strokeCount:reportedByPlayerID:) throws -> ScoreEvent`
+  - [x] 3.4 Creates ScoreEvent with `supersedesEventID: nil` (corrections are Story 3.3)
+  - [x] 3.5 Inserts into modelContext and saves; throws on failure (never `try?`)
 
-- [ ] Task 4: Add `ScoringService` to `AppServices` (AC: 2)
-  - [ ] 4.1 Add `let scoringService: ScoringService` to `AppServices`
-  - [ ] 4.2 Construct with main ModelContext and device ID (`UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString`)
+- [x] Task 4: Add `ScoringService` to `AppServices` (AC: 2)
+  - [x] 4.1 Add `let scoringService: ScoringService` to `AppServices`
+  - [x] 4.2 Construct with main ModelContext and device ID (`UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString`)
 
-- [ ] Task 5: Create `ScorecardViewModel` (AC: 1, 2, 3, 6)
-  - [ ] 5.1 Create `HyzerApp/ViewModels/ScorecardViewModel.swift` -- `@MainActor @Observable`
-  - [ ] 5.2 Constructor: `init(scoringService: ScoringService, roundID: UUID, reportedByPlayerID: UUID)`
-  - [ ] 5.3 Method: `enterScore(playerID: String, holeNumber: Int, strokeCount: Int) throws`
-  - [ ] 5.4 Property: `saveError: Error?` for error alert binding
+- [x] Task 5: Create `ScorecardViewModel` (AC: 1, 2, 3, 6)
+  - [x] 5.1 Create `HyzerApp/ViewModels/ScorecardViewModel.swift` -- `@MainActor @Observable`
+  - [x] 5.2 Constructor: `init(scoringService: ScoringService, roundID: UUID, reportedByPlayerID: UUID)`
+  - [x] 5.3 Method: `enterScore(playerID: String, holeNumber: Int, strokeCount: Int) throws`
+  - [x] 5.4 Property: `saveError: Error?` for error alert binding
 
-- [ ] Task 6: Create `ScorecardContainerView` (AC: 4, 5)
-  - [ ] 6.1 Create `HyzerApp/Views/Scoring/ScorecardContainerView.swift`
-  - [ ] 6.2 Receives `Round` object; queries ScoreEvents, Holes, Players via `@Query`
-  - [ ] 6.3 `TabView(selection: $currentHole)` with `.tabViewStyle(.page)` for horizontal paging
-  - [ ] 6.4 One `HoleCardView` per hole (1...round.holeCount), each tagged by hole number
-  - [ ] 6.5 Client-side filter for scores/holes matching this round (small dataset, no dynamic predicate needed)
+- [x] Task 6: Create `ScorecardContainerView` (AC: 4, 5)
+  - [x] 6.1 Create `HyzerApp/Views/Scoring/ScorecardContainerView.swift`
+  - [x] 6.2 Receives `Round` object; queries ScoreEvents, Holes, Players via `@Query`
+  - [x] 6.3 `TabView(selection: $currentHole)` with `.tabViewStyle(.page)` for horizontal paging
+  - [x] 6.4 One `HoleCardView` per hole (1...round.holeCount), each tagged by hole number
+  - [x] 6.5 Client-side filter for scores/holes matching this round (small dataset, no dynamic predicate needed)
 
-- [ ] Task 7: Create `HoleCardView` (AC: 1, 3, 4, 6)
-  - [ ] 7.1 Create `HyzerApp/Views/Scoring/HoleCardView.swift`
-  - [ ] 7.2 Card header: hole number (H2), par value (caption), course name (caption, secondary)
-  - [ ] 7.3 Player rows: name, score (or dash if unscored), running +/- par not required yet (Story 3.4)
-  - [ ] 7.4 Both registered players and guest players appear as rows
-  - [ ] 7.5 Tapping an unscored row expands inline `ScoreInputView`
-  - [ ] 7.6 Scored rows display the stroke count with score-state color coding
-  - [ ] 7.7 Accessibility: card labeled "Hole [n], Par [n]"; rows labeled "[name], score [n] or no score"
+- [x] Task 7: Create `HoleCardView` (AC: 1, 3, 4, 6)
+  - [x] 7.1 Create `HyzerApp/Views/Scoring/HoleCardView.swift`
+  - [x] 7.2 Card header: hole number (H2), par value (caption), course name (caption, secondary)
+  - [x] 7.3 Player rows: name, score (or dash if unscored), running +/- par not required yet (Story 3.4)
+  - [x] 7.4 Both registered players and guest players appear as rows
+  - [x] 7.5 Tapping an unscored row expands inline `ScoreInputView`
+  - [x] 7.6 Scored rows display the stroke count with score-state color coding
+  - [x] 7.7 Accessibility: card labeled "Hole [n], Par [n]"; rows labeled "[name], score [n] or no score"
 
-- [ ] Task 8: Create `ScoreInputView` (AC: 1, 2)
-  - [ ] 8.1 Create `HyzerApp/Views/Scoring/ScoreInputView.swift`
-  - [ ] 8.2 Inline picker with values 1-10, defaulting to par for the current hole (FR18)
-  - [ ] 8.3 On selection: collapse picker, fire haptic (`UIImpactFeedbackGenerator(.light)`), call enterScore
-  - [ ] 8.4 Touch targets: minimum 44pt (NFR14), scoring targets 52pt (`SpacingTokens.scoringTouchTarget`)
-  - [ ] 8.5 Accessibility: labeled "Select score for [name]"
+- [x] Task 8: Create `ScoreInputView` (AC: 1, 2)
+  - [x] 8.1 Create `HyzerApp/Views/Scoring/ScoreInputView.swift`
+  - [x] 8.2 Inline picker with values 1-10, defaulting to par for the current hole (FR18)
+  - [x] 8.3 On selection: collapse picker, fire haptic (`UIImpactFeedbackGenerator(.light)`), call enterScore
+  - [x] 8.4 Touch targets: minimum 44pt (NFR14), scoring targets 52pt (`SpacingTokens.scoringTouchTarget`)
+  - [x] 8.5 Accessibility: labeled "Select score for [name]"
 
-- [ ] Task 9: Update `HomeView` to use `ScorecardContainerView` (AC: 5)
-  - [ ] 9.1 Replace `ActiveRoundView` placeholder in `ScoringTabView` with `ScorecardContainerView`
-  - [ ] 9.2 Pass the active `Round` object to `ScorecardContainerView`
+- [x] Task 9: Update `HomeView` to use `ScorecardContainerView` (AC: 5)
+  - [x] 9.1 Replace `ActiveRoundView` placeholder in `ScoringTabView` with `ScorecardContainerView`
+  - [x] 9.2 Pass the active `Round` object to `ScorecardContainerView`
 
-- [ ] Task 10: Create `ScoreEvent+Fixture.swift` (AC: all)
-  - [ ] 10.1 Create `HyzerKit/Tests/HyzerKitTests/Fixtures/ScoreEvent+Fixture.swift`
-  - [ ] 10.2 `ScoreEvent.fixture()` with customizable defaults matching existing fixture pattern
+- [x] Task 10: Create `ScoreEvent+Fixture.swift` (AC: all)
+  - [x] 10.1 Create `HyzerKit/Tests/HyzerKitTests/Fixtures/ScoreEvent+Fixture.swift`
+  - [x] 10.2 `ScoreEvent.fixture()` with customizable defaults matching existing fixture pattern
 
-- [ ] Task 11: Write `ScoreEventModelTests` in HyzerKitTests (AC: 2)
-  - [ ] 11.1 Create `HyzerKit/Tests/HyzerKitTests/Domain/ScoreEventModelTests.swift`
-  - [ ] 11.2 Test: init creates ScoreEvent with correct properties and nil supersedesEventID
-  - [ ] 11.3 Test: ScoreEvent persists and fetches in SwiftData (in-memory)
-  - [ ] 11.4 Test: CloudKit compatibility -- all properties have defaults
-  - [ ] 11.5 Test: Multiple ScoreEvents for same {round, hole, player} coexist (append-only)
+- [x] Task 11: Write `ScoreEventModelTests` in HyzerKitTests (AC: 2)
+  - [x] 11.1 Create `HyzerKit/Tests/HyzerKitTests/Domain/ScoreEventModelTests.swift`
+  - [x] 11.2 Test: init creates ScoreEvent with correct properties and nil supersedesEventID
+  - [x] 11.3 Test: ScoreEvent persists and fetches in SwiftData (in-memory)
+  - [x] 11.4 Test: CloudKit compatibility -- all properties have defaults
+  - [x] 11.5 Test: Multiple ScoreEvents for same {round, hole, player} coexist (append-only)
 
-- [ ] Task 12: Write `ScoringServiceTests` in HyzerKitTests (AC: 2, 3)
-  - [ ] 12.1 Create `HyzerKit/Tests/HyzerKitTests/Domain/ScoringServiceTests.swift`
-  - [ ] 12.2 Test: `createScoreEvent` persists event with correct roundID, holeNumber, playerID, strokeCount
-  - [ ] 12.3 Test: `createScoreEvent` sets reportedByPlayerID and deviceID correctly
-  - [ ] 12.4 Test: `createScoreEvent` sets supersedesEventID to nil
-  - [ ] 12.5 Test: `createScoreEvent` returns the created ScoreEvent
-  - [ ] 12.6 Test: multiple events for same {round, hole, player} all persist (no uniqueness constraint)
+- [x] Task 12: Write `ScoringServiceTests` in HyzerKitTests (AC: 2, 3)
+  - [x] 12.1 Create `HyzerKit/Tests/HyzerKitTests/Domain/ScoringServiceTests.swift`
+  - [x] 12.2 Test: `createScoreEvent` persists event with correct roundID, holeNumber, playerID, strokeCount
+  - [x] 12.3 Test: `createScoreEvent` sets reportedByPlayerID and deviceID correctly
+  - [x] 12.4 Test: `createScoreEvent` sets supersedesEventID to nil
+  - [x] 12.5 Test: `createScoreEvent` returns the created ScoreEvent
+  - [x] 12.6 Test: multiple events for same {round, hole, player} all persist (no uniqueness constraint)
 
-- [ ] Task 13: Write `ScorecardViewModelTests` in HyzerAppTests (AC: 1, 2, 3)
-  - [ ] 13.1 Create `HyzerAppTests/ScorecardViewModelTests.swift`
-  - [ ] 13.2 Test: `enterScore` creates ScoreEvent via ScoringService
-  - [ ] 13.3 Test: `enterScore` passes correct roundID and reportedByPlayerID from init
-  - [ ] 13.4 Test: `enterScore` with different playerIDs creates separate events (distributed scoring)
+- [x] Task 13: Write `ScorecardViewModelTests` in HyzerAppTests (AC: 1, 2, 3)
+  - [x] 13.1 Create `HyzerAppTests/ScorecardViewModelTests.swift`
+  - [x] 13.2 Test: `enterScore` creates ScoreEvent via ScoringService
+  - [x] 13.3 Test: `enterScore` passes correct roundID and reportedByPlayerID from init
+  - [x] 13.4 Test: `enterScore` with different playerIDs creates separate events (distributed scoring)
 
 ## Dev Notes
 
@@ -523,10 +523,37 @@ Key learnings from Story 3.1 that directly apply:
 
 ### Agent Model Used
 
-{{agent_model_name_version}}
+claude-sonnet-4-6
 
 ### Debug Log References
 
 ### Completion Notes List
 
+- Created `ScoreEvent` SwiftData model with append-only invariant (no public update/delete API), CloudKit-compatible (all properties have defaults, no @Attribute(.unique), no @Relationship, playerID as String for guest support).
+- Created `ScoringService` — plain class (not actor) using main ModelContext; `createScoreEvent` always throws on failure (never try?). supersedesEventID set to nil for all Story 3.2 events.
+- Registered `ScoreEvent.self` in domain ModelContainer schema in `HyzerApp.swift`.
+- Added `scoringService: ScoringService` to `AppServices` composition root; device ID sourced from `UIDevice.current.identifierForVendor`.
+- `ScorecardViewModel` is `@MainActor @Observable` with `enterScore` throwing method and `saveError` for alert binding.
+- `ScorecardContainerView` uses `TabView(.page)` for horizontal hole card stack; client-side filters for ScoreEvents and Holes (max ~108 events per round); queries Courses for course name display; initializes ViewModel on appear.
+- `ScorecardPlayer` struct unifies registered players (Player.id.uuidString) and guests ("guest:{name}") into a single identifiable list.
+- `HoleCardView` implements Amendment A7 current-score resolution (leaf node in supersession chain); score-state color coding via ColorTokens (scoreUnderPar/scoreAtPar/scoreOverPar/scoreWayOver); animated inline picker expansion; full accessibility labels.
+- `ScoreInputView` shows 1–10 scores with par visually anchored (accent color background); 52pt touch targets per NFR14; UIImpactFeedbackGenerator(.light) haptic on selection.
+- Removed `ActiveRoundView` placeholder and its unused helper methods/queries from `HomeView`.
+- HyzerKit tests (35/35 pass). iOS simulator tests blocked by pre-existing iOS 26 + SwiftData + AppGroup incompatibility (same as all prior stories — not a code issue).
+- SwiftLint: no errors or warnings.
+
 ### File List
+
+- `HyzerKit/Sources/HyzerKit/Models/ScoreEvent.swift` — created
+- `HyzerKit/Sources/HyzerKit/Domain/ScoringService.swift` — created
+- `HyzerApp/App/HyzerApp.swift` — modified (added ScoreEvent to ModelContainer)
+- `HyzerApp/App/AppServices.swift` — modified (added scoringService, UIKit import)
+- `HyzerApp/ViewModels/ScorecardViewModel.swift` — created
+- `HyzerApp/Views/Scoring/ScorecardContainerView.swift` — created
+- `HyzerApp/Views/Scoring/HoleCardView.swift` — created
+- `HyzerApp/Views/Scoring/ScoreInputView.swift` — created
+- `HyzerApp/Views/HomeView.swift` — modified (replaced ActiveRoundView with ScorecardContainerView, removed unused code)
+- `HyzerKit/Tests/HyzerKitTests/Fixtures/ScoreEvent+Fixture.swift` — created
+- `HyzerKit/Tests/HyzerKitTests/Domain/ScoreEventModelTests.swift` — created
+- `HyzerKit/Tests/HyzerKitTests/Domain/ScoringServiceTests.swift` — created
+- `HyzerAppTests/ScorecardViewModelTests.swift` — created

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -28,7 +28,7 @@ stories:
     epic: 3
   "3.2":
     title: "Hole Card Tap Scoring & ScoreEvent Creation"
-    status: in-progress
+    status: review
     epic: 3
   "3.3":
     title: "Score Corrections & Hole Navigation"


### PR DESCRIPTION
Closes #7

## User Story

As a user, I want to tap a player's row on a hole card to enter their score, so that I can record scores quickly and accurately during a round.

## Changes

```
 HyzerApp.xcodeproj/project.pbxproj                 |  28 +++
 HyzerApp/App/AppServices.swift                     |   4 +
 HyzerApp/App/HyzerApp.swift                        |   6 +-
 HyzerApp/ViewModels/ScorecardViewModel.swift       |  38 ++++
 HyzerApp/Views/HomeView.swift                      |  45 +----
 HyzerApp/Views/Scoring/HoleCardView.swift          | 148 +++++++++++++++
 HyzerApp/Views/Scoring/ScoreInputView.swift        |  79 ++++++++
 HyzerApp/Views/Scoring/ScorecardContainerView.swift| 119 ++++++++++++
 HyzerAppTests/ScorecardViewModelTests.swift        |  94 ++++++++++
 HyzerKit/.../Domain/ScoringService.swift           |  52 ++++++
 HyzerKit/.../Models/ScoreEvent.swift               |  51 ++++++
 HyzerKit/.../Domain/ScoreEventModelTests.swift     | 151 +++++++++++++++
 HyzerKit/.../Domain/ScoringServiceTests.swift      | 139 ++++++++++++++
 HyzerKit/.../Fixtures/ScoreEvent+Fixture.swift     |  23 +++
 16 files changed, 1054 insertions(+), 128 deletions(-)
```

### New Models & Services (HyzerKit)
- `ScoreEvent` SwiftData model — append-only, CloudKit-compatible (all properties have defaults, no `@Attribute(.unique)`, no `@Relationship`); `playerID` is String to support both registered players and guests (`"guest:{name}"`)
- `ScoringService` — creates immutable `ScoreEvent` records; `createScoreEvent()` throws on failure, never uses `try?`; `supersedesEventID` always nil (corrections are Story 3.3); precondition guards for strokeCount (1-10) and holeNumber (>= 1)

### App-Level Changes
- `HyzerApp.swift` — added `ScoreEvent.self` to domain `ModelContainer` schema
- `AppServices.swift` — added `scoringService: ScoringService` property; device ID from `UIDevice.current.identifierForVendor`
- `ScorecardViewModel.swift` — `@MainActor @Observable`; `enterScore()` delegates to `ScoringService`; `saveError` for error alert binding
- `ScorecardContainerView.swift` — `TabView(.page)` horizontal hole card stack; client-side filtering (small dataset); computed `Binding` for error alert; initializes ViewModel on appear
- `HoleCardView.swift` — hole header with H2 number + caption par/course; player rows with Amendment A7 current-score resolution (leaf-node supersession); score-state color coding; AnimationTokens + AnimationCoordinator with reduce-motion support; scored rows disabled (corrections are Story 3.3); full a11y labels
- `ScoreInputView.swift` — inline 1-10 picker with par visually anchored (accent background); horizontal ScrollView for NFR14 compliance on all screen sizes; 52pt touch targets; par-centered scroll anchor; pre-prepared `UIImpactFeedbackGenerator(.light)` haptic
- `HomeView.swift` — replaced `ActiveRoundView` placeholder with `ScorecardContainerView`; removed unused helper code

## Test Coverage

**HyzerKitTests (35 tests, all passing):**
- `ScoreEventModelTests` — init properties, SwiftData persistence, CloudKit compatibility, append-only coexistence, fixture helper
- `ScoringServiceTests` — createScoreEvent properties, reportedByPlayerID/deviceID, nil supersedesEventID, returns event, no uniqueness constraint

**HyzerAppTests:**
- `ScorecardViewModelTests` — enterScore creates event, passes correct roundID/reportedByPlayerID, distributed scoring creates separate events per playerID

Note: iOS simulator tests are blocked by a pre-existing iOS 26 + SwiftData + AppGroup incompatibility (same issue as all prior stories — not a code regression).

---
_Developed via BMAD workflow_