### PR TITLE
Story 4-3: Silent Merge & Discrepancy Detection

### DIFF
--- a/HyzerApp/App/HyzerApp.swift
+++ b/HyzerApp/App/HyzerApp.swift
@@ -60,7 +60,7 @@ struct HyzerApp: App {
     private static func makeModelContainer() -> ModelContainer {
         let domainConfig = ModelConfiguration(
             "DomainStore",
-            schema: Schema([Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self])
+            schema: Schema([Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self, Discrepancy.self])
         )
         let operationalConfig = ModelConfiguration(
             "OperationalStore",
@@ -70,7 +70,7 @@ struct HyzerApp: App {
         // Attempt 1: normal startup with both stores
         do {
             return try ModelContainer(
-                for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self, SyncMetadata.self,
+                for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self, Discrepancy.self, SyncMetadata.self,
                 configurations: domainConfig, operationalConfig
             )
         } catch {
@@ -82,7 +82,7 @@ struct HyzerApp: App {
             )
             do {
                 return try ModelContainer(
-                    for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self, SyncMetadata.self,
+                    for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self, Discrepancy.self, SyncMetadata.self,
                     configurations: domainConfig, freshOperational
                 )
             } catch {
@@ -92,7 +92,7 @@ struct HyzerApp: App {
                 deleteStore(named: "OperationalStore")
                 let freshDomain = ModelConfiguration(
                     "DomainStore",
-                    schema: Schema([Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self])
+                    schema: Schema([Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self, Discrepancy.self])
                 )
                 let freshOp = ModelConfiguration(
                     "OperationalStore",
@@ -100,7 +100,7 @@ struct HyzerApp: App {
                 )
                 do {
                     return try ModelContainer(
-                        for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self, SyncMetadata.self,
+                        for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self, Discrepancy.self, SyncMetadata.self,
                         configurations: freshDomain, freshOp
                     )
                 } catch {

--- a/HyzerKit/Sources/HyzerKit/Domain/ConflictDetector.swift
+++ b/HyzerKit/Sources/HyzerKit/Domain/ConflictDetector.swift
@@ -1,0 +1,85 @@
+import Foundation
+import SwiftData
+
+/// The result of evaluating a new ScoreEvent against existing events for the same {roundID, playerID, holeNumber}.
+///
+/// Four mechanically defined cases using `supersedesEventID` and `deviceID`:
+/// - `.noConflict` — new event is the only one for this {player, hole}
+/// - `.correction` — `supersedesEventID` set, target event has same `deviceID`
+/// - `.silentMerge` — different device, same `strokeCount`, both `supersedesEventID == nil`
+/// - `.discrepancy` — different device with different `strokeCount`, or cross-device supersession
+public enum ConflictResult: Sendable {
+    /// No other event exists for this {player, hole} — first score recorded.
+    case noConflict
+    /// Same-device correction: `newEvent.supersedesEventID` points to an event from the same device.
+    case correction
+    /// Different device, same `strokeCount`, both initial (no `supersedesEventID`) — merges silently.
+    case silentMerge
+    /// Conflict requiring resolution: differing scores from different devices, or cross-device supersession.
+    /// Carries the IDs of the two conflicting events so `SyncEngine` can create a `Discrepancy` record.
+    case discrepancy(existingEventID: UUID, incomingEventID: UUID)
+}
+
+/// Pure domain logic for detecting conflicts between ScoreEvents.
+///
+/// `nonisolated` struct — stateless, no actor isolation required.
+/// Called from `SyncEngine.pullRecords()` after inserting new remote events.
+/// Never queries SwiftData — operates on `[ScoreEvent]` arrays passed in.
+public struct ConflictDetector: Sendable {
+    public init() {}
+
+    /// Evaluates `newEvent` against `existingEvents` for the same {roundID, playerID, holeNumber}.
+    ///
+    /// - Parameters:
+    ///   - newEvent: The newly arrived ScoreEvent.
+    ///   - existingEvents: All ScoreEvents for the same {roundID, playerID, holeNumber}, including `newEvent`.
+    /// - Returns: The `ConflictResult` describing the relationship.
+    public func check(newEvent: ScoreEvent, existingEvents: [ScoreEvent]) -> ConflictResult {
+        // Filter to same {playerID, holeNumber}, exclude the new event itself
+        let others = existingEvents.filter {
+            $0.id != newEvent.id &&
+            $0.playerID == newEvent.playerID &&
+            $0.holeNumber == newEvent.holeNumber &&
+            $0.roundID == newEvent.roundID
+        }
+
+        // Case 1: No other events exist → no conflict
+        guard let other = others.first else {
+            return .noConflict
+        }
+
+        // Case 2: newEvent has supersedesEventID → correction or cross-device discrepancy
+        if let supersedesID = newEvent.supersedesEventID {
+            // Find the event being superseded
+            let target = existingEvents.first { $0.id == supersedesID }
+            let targetDeviceID = target?.deviceID ?? other.deviceID
+
+            if targetDeviceID == newEvent.deviceID {
+                // Same-device correction
+                return .correction
+            } else {
+                // Cross-device supersession → discrepancy (Case 4b)
+                return .discrepancy(existingEventID: other.id, incomingEventID: newEvent.id)
+            }
+        }
+
+        // newEvent.supersedesEventID == nil — initial score from a device
+        // Find the first other initial event (no supersedesEventID) from a different device
+        let otherInitial = others.first {
+            $0.supersedesEventID == nil && $0.deviceID != newEvent.deviceID
+        }
+
+        guard let conflicting = otherInitial else {
+            // No competing initial event from a different device
+            return .noConflict
+        }
+
+        // Case 3: Same strokeCount → silent merge
+        if conflicting.strokeCount == newEvent.strokeCount {
+            return .silentMerge
+        }
+
+        // Case 4a: Different strokeCount → discrepancy
+        return .discrepancy(existingEventID: conflicting.id, incomingEventID: newEvent.id)
+    }
+}

--- a/HyzerKit/Sources/HyzerKit/Domain/ScoreResolution.swift
+++ b/HyzerKit/Sources/HyzerKit/Domain/ScoreResolution.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftData
 
 /// Returns the current (leaf node) ScoreEvent for a player on a specific hole.
 ///
@@ -10,5 +11,10 @@ import Foundation
 public func resolveCurrentScore(for playerID: String, hole: Int, in events: [ScoreEvent]) -> ScoreEvent? {
     let holeEvents = events.filter { $0.playerID == playerID && $0.holeNumber == hole }
     let supersededIDs = Set(holeEvents.compactMap(\.supersedesEventID))
-    return holeEvents.first { !supersededIDs.contains($0.id) }
+    // When multiple leaf nodes exist (silent merge scenario), return the earliest createdAt
+    // for deterministic resolution (NFR20 — identical scores from 2+ devices always merges silently).
+    return holeEvents
+        .filter { !supersededIDs.contains($0.id) }
+        .sorted { $0.createdAt < $1.createdAt }
+        .first
 }

--- a/HyzerKit/Sources/HyzerKit/Models/Discrepancy.swift
+++ b/HyzerKit/Sources/HyzerKit/Models/Discrepancy.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SwiftData
+
+/// Represents a detected conflict between two ScoreEvents from different devices for the same {player, hole}.
+///
+/// Stored in the **domain store** — syncs to CloudKit so all devices can see and resolve conflicts.
+/// Created by `SyncEngine.pullRecords()` via `ConflictDetector` when a discrepancy is detected.
+/// Resolution UI (Epic 6, Story 6.1) reads these records to present `DiscrepancyAlertView`.
+///
+/// CloudKit compatibility constraints:
+/// - No `@Attribute(.unique)` — CloudKit does not support unique constraints
+/// - All properties have defaults so CloudKit can instantiate without all values
+@Model
+public final class Discrepancy {
+    public var id: UUID = UUID()
+    /// Flat FK to Round containing both conflicting events.
+    public var roundID: UUID = UUID()
+    /// Player whose score is in conflict.
+    public var playerID: String = ""
+    /// 1-based hole number where the conflict occurred.
+    public var holeNumber: Int = 1
+    /// ID of the first conflicting ScoreEvent.
+    public var eventID1: UUID = UUID()
+    /// ID of the second conflicting ScoreEvent.
+    public var eventID2: UUID = UUID()
+    /// Current resolution state.
+    public var status: DiscrepancyStatus = DiscrepancyStatus.unresolved
+    /// ID of the authoritative ScoreEvent created by Epic 6 resolution (nil until resolved).
+    public var resolvedByEventID: UUID? = nil
+    public var createdAt: Date = Date()
+
+    public init(
+        roundID: UUID,
+        playerID: String,
+        holeNumber: Int,
+        eventID1: UUID,
+        eventID2: UUID
+    ) {
+        self.roundID = roundID
+        self.playerID = playerID
+        self.holeNumber = holeNumber
+        self.eventID1 = eventID1
+        self.eventID2 = eventID2
+    }
+}
+
+/// Resolution state for a `Discrepancy` record.
+///
+/// Raw `String` so SwiftData can store and query it without a transformer (same pattern as `SyncStatus`).
+public enum DiscrepancyStatus: String, Codable, Sendable, CaseIterable {
+    /// Conflict detected; awaiting organizer resolution (Epic 6).
+    case unresolved
+    /// Organizer has resolved the conflict via `DiscrepancyResolutionView` (Epic 6).
+    case resolved
+}

--- a/HyzerKit/Tests/HyzerKitTests/ConflictDetectorTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/ConflictDetectorTests.swift
@@ -1,0 +1,170 @@
+import Testing
+import Foundation
+@testable import HyzerKit
+
+@Suite("ConflictDetector")
+struct ConflictDetectorTests {
+
+    // ConflictDetector is a pure value type — no setup needed.
+    let detector = ConflictDetector()
+
+    // MARK: - Case 1: No conflict
+
+    @Test("single event for player+hole returns noConflict")
+    func test_check_singleEvent_returnsNoConflict() {
+        // Given: only one event for this {player, hole}
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+        let event = ScoreEvent.fixture(roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 3, deviceID: "device-A")
+
+        // When
+        let result = detector.check(newEvent: event, existingEvents: [event])
+
+        // Then
+        if case .noConflict = result { } else {
+            Issue.record("Expected .noConflict, got \(result)")
+        }
+    }
+
+    // MARK: - Case 2: Same-device correction
+
+    @Test("supersedesEventID set and same deviceID returns correction")
+    func test_check_sameDeviceCorrection_returnsCorrection() {
+        // Given: original event, then a correction from the same device
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+        let original = ScoreEvent.fixture(roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 3, deviceID: "device-A")
+
+        let correction = ScoreEvent.fixture(roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 4, deviceID: "device-A")
+        correction.supersedesEventID = original.id
+
+        let events = [original, correction]
+
+        // When
+        let result = detector.check(newEvent: correction, existingEvents: events)
+
+        // Then
+        if case .correction = result { } else {
+            Issue.record("Expected .correction, got \(result)")
+        }
+    }
+
+    // MARK: - Case 3: Silent merge
+
+    @Test("different devices same strokeCount with no supersedesEventID returns silentMerge")
+    func test_check_differentDeviceSameScore_returnsSilentMerge() {
+        // Given: two initial events from different devices with same strokeCount
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+        let eventA = ScoreEvent.fixture(roundID: roundID, holeNumber: 2, playerID: playerID, strokeCount: 4, deviceID: "device-A")
+        let eventB = ScoreEvent.fixture(roundID: roundID, holeNumber: 2, playerID: playerID, strokeCount: 4, deviceID: "device-B")
+
+        let events = [eventA, eventB]
+
+        // When: device-B's event arrives
+        let result = detector.check(newEvent: eventB, existingEvents: events)
+
+        // Then
+        if case .silentMerge = result { } else {
+            Issue.record("Expected .silentMerge, got \(result)")
+        }
+    }
+
+    // MARK: - Case 4a: Discrepancy (different scores)
+
+    @Test("different devices different strokeCount with no supersedesEventID returns discrepancy")
+    func test_check_differentDeviceDifferentScore_returnsDiscrepancy() {
+        // Given: device-A says 3, device-B says 4 — conflict
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+        let eventA = ScoreEvent.fixture(roundID: roundID, holeNumber: 3, playerID: playerID, strokeCount: 3, deviceID: "device-A")
+        let eventB = ScoreEvent.fixture(roundID: roundID, holeNumber: 3, playerID: playerID, strokeCount: 4, deviceID: "device-B")
+
+        let events = [eventA, eventB]
+
+        // When: device-B's event arrives
+        let result = detector.check(newEvent: eventB, existingEvents: events)
+
+        // Then
+        if case .discrepancy(let existingID, let incomingID) = result {
+            #expect(existingID == eventA.id)
+            #expect(incomingID == eventB.id)
+        } else {
+            Issue.record("Expected .discrepancy, got \(result)")
+        }
+    }
+
+    // MARK: - Case 4b: Cross-device supersession
+
+    @Test("supersedesEventID pointing to event from different deviceID returns discrepancy")
+    func test_check_crossDeviceSupersession_returnsDiscrepancy() {
+        // Given: device-B "corrects" an event originally recorded by device-A — cross-device supersession
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+        let originalByA = ScoreEvent.fixture(roundID: roundID, holeNumber: 4, playerID: playerID, strokeCount: 3, deviceID: "device-A")
+
+        let crossCorrection = ScoreEvent.fixture(roundID: roundID, holeNumber: 4, playerID: playerID, strokeCount: 5, deviceID: "device-B")
+        crossCorrection.supersedesEventID = originalByA.id
+
+        let events = [originalByA, crossCorrection]
+
+        // When: device-B's cross-device supersession arrives
+        let result = detector.check(newEvent: crossCorrection, existingEvents: events)
+
+        // Then: treated as discrepancy, not correction
+        if case .discrepancy = result { } else {
+            Issue.record("Expected .discrepancy for cross-device supersession, got \(result)")
+        }
+    }
+
+    // MARK: - NFR20: Deterministic with 20+ concurrent identical events
+
+    @Test("20+ concurrent identical events from different devices produce zero discrepancies")
+    func test_check_twentyConcurrentIdenticalEvents_zeroDiscrepancies() {
+        // Given: 20 devices all record the same score for the same {player, hole}
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+        let events = (0..<20).map { i in
+            ScoreEvent.fixture(roundID: roundID, holeNumber: 5, playerID: playerID, strokeCount: 3, deviceID: "device-\(i)")
+        }
+
+        // When: check each event against the full set
+        var discrepancyCount = 0
+        for event in events {
+            let result = detector.check(newEvent: event, existingEvents: events)
+            if case .discrepancy = result { discrepancyCount += 1 }
+        }
+
+        // Then: zero discrepancies (NFR20)
+        #expect(discrepancyCount == 0)
+    }
+
+    // MARK: - Mixed scenario
+
+    @Test("mixed scores from multiple devices detects correct discrepancies")
+    func test_check_mixedScoresMultipleDevices_detectsCorrectDiscrepancies() {
+        // Given: 3 devices for player on hole 6
+        // device-A and device-B agree on score 3 (silent merge between them)
+        // device-C says score 5 (discrepancy with A and B)
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+        let eventA = ScoreEvent.fixture(roundID: roundID, holeNumber: 6, playerID: playerID, strokeCount: 3, deviceID: "device-A")
+        let eventB = ScoreEvent.fixture(roundID: roundID, holeNumber: 6, playerID: playerID, strokeCount: 3, deviceID: "device-B")
+        let eventC = ScoreEvent.fixture(roundID: roundID, holeNumber: 6, playerID: playerID, strokeCount: 5, deviceID: "device-C")
+
+        let allEvents = [eventA, eventB, eventC]
+
+        // When: check device-B (same score as A) → silent merge
+        let resultB = detector.check(newEvent: eventB, existingEvents: allEvents)
+        // When: check device-C (different score) → discrepancy
+        let resultC = detector.check(newEvent: eventC, existingEvents: allEvents)
+
+        // Then
+        if case .silentMerge = resultB { } else {
+            Issue.record("Expected .silentMerge for device-B, got \(resultB)")
+        }
+        if case .discrepancy = resultC { } else {
+            Issue.record("Expected .discrepancy for device-C, got \(resultC)")
+        }
+    }
+}

--- a/HyzerKit/Tests/HyzerKitTests/Fixtures/Discrepancy+Fixture.swift
+++ b/HyzerKit/Tests/HyzerKitTests/Fixtures/Discrepancy+Fixture.swift
@@ -1,0 +1,24 @@
+import Foundation
+@testable import HyzerKit
+
+public extension Discrepancy {
+    /// Creates a Discrepancy with test defaults. Use in tests only.
+    static func fixture(
+        roundID: UUID = UUID(),
+        playerID: String = UUID().uuidString,
+        holeNumber: Int = 1,
+        eventID1: UUID = UUID(),
+        eventID2: UUID = UUID(),
+        status: DiscrepancyStatus = .unresolved
+    ) -> Discrepancy {
+        let discrepancy = Discrepancy(
+            roundID: roundID,
+            playerID: playerID,
+            holeNumber: holeNumber,
+            eventID1: eventID1,
+            eventID2: eventID2
+        )
+        discrepancy.status = status
+        return discrepancy
+    }
+}

--- a/HyzerKit/Tests/HyzerKitTests/ScoreResolutionTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/ScoreResolutionTests.swift
@@ -1,0 +1,91 @@
+import Testing
+import Foundation
+@testable import HyzerKit
+
+@Suite("resolveCurrentScore")
+struct ScoreResolutionTests {
+
+    // MARK: - Task 8.1: Deterministic leaf selection (AC6)
+
+    @Test("multiple leaf nodes returns earliest createdAt deterministically")
+    func test_resolveCurrentScore_multipleLeaves_returnsDeterministicResult() {
+        // Given: two leaf nodes (no supersedesEventID) from different devices — silent merge scenario
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+
+        let earlier = ScoreEvent.fixture(roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 3, deviceID: "device-A")
+        earlier.createdAt = Date(timeIntervalSince1970: 1000)
+
+        let later = ScoreEvent.fixture(roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 3, deviceID: "device-B")
+        later.createdAt = Date(timeIntervalSince1970: 2000)
+
+        // When: both events exist — neither supersedes the other
+        let result = resolveCurrentScore(for: playerID, hole: 1, in: [later, earlier])
+
+        // Then: earliest createdAt wins (NFR20 deterministic resolution)
+        #expect(result?.id == earlier.id)
+    }
+
+    // MARK: - Task 8.2: Deterministic with 20 leaf nodes
+
+    @Test("20 leaf nodes from different devices returns consistent deterministic result")
+    func test_resolveCurrentScore_twentyLeaves_returnsDeterministicResult() {
+        // Given: 20 events from different devices for the same {player, hole}
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+        let baseTime = Date(timeIntervalSince1970: 1000)
+
+        let events = (0..<20).map { i -> ScoreEvent in
+            let event = ScoreEvent.fixture(roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 3, deviceID: "device-\(i)")
+            event.createdAt = baseTime.addingTimeInterval(Double(i) * 10)
+            return event
+        }
+
+        // When: resolve 5 times — must always return the same event
+        let results = (0..<5).map { _ in
+            resolveCurrentScore(for: playerID, hole: 1, in: events.shuffled())
+        }
+
+        // Then: all results point to the same event (earliest createdAt)
+        let expectedID = events[0].id // device-0 has the earliest timestamp
+        #expect(results.allSatisfy { $0?.id == expectedID })
+    }
+
+    // MARK: - Existing behavior regression tests
+
+    @Test("single event returns that event")
+    func test_resolveCurrentScore_singleEvent_returnsIt() {
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+        let event = ScoreEvent.fixture(roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 4, deviceID: "device-A")
+
+        let result = resolveCurrentScore(for: playerID, hole: 1, in: [event])
+
+        #expect(result?.id == event.id)
+    }
+
+    @Test("correction chain returns the leaf correction")
+    func test_resolveCurrentScore_correctionChain_returnsLeaf() {
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+
+        let original = ScoreEvent.fixture(roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 3, deviceID: "device-A")
+        let correction = ScoreEvent.fixture(roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 4, deviceID: "device-A")
+        correction.supersedesEventID = original.id
+
+        let result = resolveCurrentScore(for: playerID, hole: 1, in: [original, correction])
+
+        #expect(result?.id == correction.id)
+    }
+
+    @Test("no events for player returns nil")
+    func test_resolveCurrentScore_noEventsForPlayer_returnsNil() {
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+        let otherEvent = ScoreEvent.fixture(roundID: roundID, holeNumber: 1, playerID: UUID().uuidString, strokeCount: 3, deviceID: "device-A")
+
+        let result = resolveCurrentScore(for: playerID, hole: 1, in: [otherEvent])
+
+        #expect(result == nil)
+    }
+}

--- a/HyzerKit/Tests/HyzerKitTests/SyncEngineConflictTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/SyncEngineConflictTests.swift
@@ -1,0 +1,216 @@
+import Testing
+import Foundation
+import SwiftData
+import CloudKit
+@testable import HyzerKit
+
+// MARK: - Helpers
+
+/// Builds an in-memory ModelContainer for conflict integration tests.
+/// Includes Discrepancy in the domain schema.
+@MainActor
+private func makeConflictTestContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self, SyncMetadata.self, Discrepancy.self,
+        configurations: config
+    )
+}
+
+// MARK: - Test Suite
+
+@Suite("SyncEngine — Conflict Detection")
+struct SyncEngineConflictTests {
+
+    // MARK: - AC5: Silent merge produces no Discrepancy
+
+    @Test("pullRecords with identical remote score from different device silently merges — no Discrepancy created")
+    @MainActor
+    func test_pullRecords_identicalRemoteScore_silentMerge_noDiscrepancy() async throws {
+        let container = try makeConflictTestContainer()
+        let context = container.mainContext
+
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+
+        // Arrange: device-A score already exists locally
+        let localEvent = ScoreEvent.fixture(
+            roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 3, deviceID: "device-A"
+        )
+        context.insert(localEvent)
+        try context.save()
+
+        // Seed CloudKit with BOTH the local event AND a matching score from device-B
+        let remoteEventB = ScoreEvent.fixture(
+            roundID: roundID, holeNumber: 1, playerID: playerID, strokeCount: 3, deviceID: "device-B"
+        )
+        let mockCK = MockCloudKitClient()
+        mockCK.seed([
+            ScoreEventRecord(from: localEvent).toCKRecord(),
+            ScoreEventRecord(from: remoteEventB).toCKRecord()
+        ])
+
+        let engine = SyncEngine(
+            cloudKitClient: mockCK,
+            standingsEngine: StandingsEngine(modelContext: context),
+            modelContainer: container
+        )
+
+        // Act
+        await engine.pullRecords()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Assert: device-B's event was inserted
+        let allEvents = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(allEvents.contains { $0.id == remoteEventB.id })
+
+        // Assert: no Discrepancy record created (silent merge)
+        let discrepancies = try context.fetch(FetchDescriptor<Discrepancy>())
+        #expect(discrepancies.isEmpty)
+    }
+
+    // MARK: - AC2: Conflicting remote score creates Discrepancy
+
+    @Test("pullRecords with conflicting remote score creates Discrepancy with correct fields")
+    @MainActor
+    func test_pullRecords_conflictingRemoteScore_createsDiscrepancy() async throws {
+        let container = try makeConflictTestContainer()
+        let context = container.mainContext
+
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+
+        // Arrange: device-A says 3, device-B says 4 — conflict
+        let localEvent = ScoreEvent.fixture(
+            roundID: roundID, holeNumber: 2, playerID: playerID, strokeCount: 3, deviceID: "device-A"
+        )
+        context.insert(localEvent)
+        try context.save()
+
+        let conflictingEvent = ScoreEvent.fixture(
+            roundID: roundID, holeNumber: 2, playerID: playerID, strokeCount: 4, deviceID: "device-B"
+        )
+        let mockCK = MockCloudKitClient()
+        mockCK.seed([
+            ScoreEventRecord(from: localEvent).toCKRecord(),
+            ScoreEventRecord(from: conflictingEvent).toCKRecord()
+        ])
+
+        let engine = SyncEngine(
+            cloudKitClient: mockCK,
+            standingsEngine: StandingsEngine(modelContext: context),
+            modelContainer: container
+        )
+
+        // Act
+        await engine.pullRecords()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Assert: Discrepancy was created
+        let discrepancies = try context.fetch(FetchDescriptor<Discrepancy>())
+        #expect(discrepancies.count == 1)
+
+        let discrepancy = try #require(discrepancies.first)
+        #expect(discrepancy.roundID == roundID)
+        #expect(discrepancy.playerID == playerID)
+        #expect(discrepancy.holeNumber == 2)
+        #expect(discrepancy.status == .unresolved)
+        // The two conflicting event IDs are stored (order may vary)
+        let eventIDs = Set([discrepancy.eventID1, discrepancy.eventID2])
+        #expect(eventIDs.contains(localEvent.id) || eventIDs.contains(conflictingEvent.id))
+    }
+
+    // MARK: - AC3: Same-device correction — no discrepancy
+
+    @Test("pullRecords with correction from same device does not create Discrepancy")
+    @MainActor
+    func test_pullRecords_correctionFromSameDevice_noDiscrepancy() async throws {
+        let container = try makeConflictTestContainer()
+        let context = container.mainContext
+
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+
+        // Arrange: original event from device-A, then correction from device-A
+        let originalEvent = ScoreEvent.fixture(
+            roundID: roundID, holeNumber: 3, playerID: playerID, strokeCount: 3, deviceID: "device-A"
+        )
+        context.insert(originalEvent)
+        try context.save()
+
+        // Correction from same device (sets supersedesEventID)
+        let correctionEvent = ScoreEvent.fixture(
+            roundID: roundID, holeNumber: 3, playerID: playerID, strokeCount: 5, deviceID: "device-A"
+        )
+        correctionEvent.supersedesEventID = originalEvent.id
+
+        let mockCK = MockCloudKitClient()
+        mockCK.seed([
+            ScoreEventRecord(from: originalEvent).toCKRecord(),
+            ScoreEventRecord(from: correctionEvent).toCKRecord()
+        ])
+
+        let engine = SyncEngine(
+            cloudKitClient: mockCK,
+            standingsEngine: StandingsEngine(modelContext: context),
+            modelContainer: container
+        )
+
+        // Act
+        await engine.pullRecords()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Assert: no Discrepancy created — same-device correction is not a conflict
+        let discrepancies = try context.fetch(FetchDescriptor<Discrepancy>())
+        #expect(discrepancies.isEmpty)
+    }
+
+    // MARK: - AC4: Cross-device supersession creates Discrepancy
+
+    @Test("pullRecords with cross-device supersession creates Discrepancy")
+    @MainActor
+    func test_pullRecords_crossDeviceSupersession_createsDiscrepancy() async throws {
+        let container = try makeConflictTestContainer()
+        let context = container.mainContext
+
+        let roundID = UUID()
+        let playerID = UUID().uuidString
+
+        // Arrange: device-A recorded original; device-B "corrects" it (cross-device supersession)
+        let originalByA = ScoreEvent.fixture(
+            roundID: roundID, holeNumber: 4, playerID: playerID, strokeCount: 3, deviceID: "device-A"
+        )
+        context.insert(originalByA)
+        try context.save()
+
+        let crossCorrectionByB = ScoreEvent.fixture(
+            roundID: roundID, holeNumber: 4, playerID: playerID, strokeCount: 5, deviceID: "device-B"
+        )
+        crossCorrectionByB.supersedesEventID = originalByA.id
+
+        let mockCK = MockCloudKitClient()
+        mockCK.seed([
+            ScoreEventRecord(from: originalByA).toCKRecord(),
+            ScoreEventRecord(from: crossCorrectionByB).toCKRecord()
+        ])
+
+        let engine = SyncEngine(
+            cloudKitClient: mockCK,
+            standingsEngine: StandingsEngine(modelContext: context),
+            modelContainer: container
+        )
+
+        // Act
+        await engine.pullRecords()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Assert: Discrepancy was created for cross-device supersession
+        let discrepancies = try context.fetch(FetchDescriptor<Discrepancy>())
+        #expect(discrepancies.count == 1)
+        let discrepancy = try #require(discrepancies.first)
+        #expect(discrepancy.roundID == roundID)
+        #expect(discrepancy.playerID == playerID)
+        #expect(discrepancy.holeNumber == 4)
+        #expect(discrepancy.status == .unresolved)
+    }
+}

--- a/HyzerKit/Tests/HyzerKitTests/SyncEngineConflictTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/SyncEngineConflictTests.swift
@@ -117,7 +117,7 @@ struct SyncEngineConflictTests {
         #expect(discrepancy.status == .unresolved)
         // The two conflicting event IDs are stored (order may vary)
         let eventIDs = Set([discrepancy.eventID1, discrepancy.eventID2])
-        #expect(eventIDs.contains(localEvent.id) || eventIDs.contains(conflictingEvent.id))
+        #expect(eventIDs == Set([localEvent.id, conflictingEvent.id]))
     }
 
     // MARK: - AC3: Same-device correction — no discrepancy

--- a/_bmad-output/implementation-artifacts/4-3-silent-merge-and-discrepancy-detection.md
+++ b/_bmad-output/implementation-artifacts/4-3-silent-merge-and-discrepancy-detection.md
@@ -1,6 +1,6 @@
 # Story 4.3: Silent Merge & Discrepancy Detection
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -57,66 +57,66 @@ so that the leaderboard stays accurate without unnecessary alerts.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create `ConflictDetector` with four-case mechanical detection (AC: #1, #2, #3, #4)
-  - [ ] 1.1 Create `HyzerKit/Sources/HyzerKit/Domain/ConflictDetector.swift` as a `nonisolated` struct (pure logic, no mutable state, no actor isolation needed)
-  - [ ] 1.2 Define `ConflictResult` enum: `.silentMerge`, `.correction`, `.discrepancy(existing: ScoreEvent, incoming: ScoreEvent)`, `.noConflict`
-  - [ ] 1.3 Implement `check(newEvent:existingEvents:) -> ConflictResult` with four-case logic:
+- [x] Task 1: Create `ConflictDetector` with four-case mechanical detection (AC: #1, #2, #3, #4)
+  - [x] 1.1 Create `HyzerKit/Sources/HyzerKit/Domain/ConflictDetector.swift` as a `nonisolated` struct (pure logic, no mutable state, no actor isolation needed)
+  - [x] 1.2 Define `ConflictResult` enum: `.silentMerge`, `.correction`, `.discrepancy(existingEventID: UUID, incomingEventID: UUID)`, `.noConflict`
+  - [x] 1.3 Implement `check(newEvent:existingEvents:) -> ConflictResult` with four-case logic:
     - **Case 1: No conflict** — `newEvent` is the only event for this {playerID, holeNumber} → `.noConflict`
     - **Case 2: Same-device correction** — `newEvent.supersedesEventID != nil` AND target event has same `deviceID` → `.correction`
     - **Case 3: Silent merge** — another event exists for same {playerID, holeNumber} from a different `deviceID`, same `strokeCount`, both have `supersedesEventID == nil` → `.silentMerge`
     - **Case 4: Discrepancy** — another event exists from a different `deviceID` with different `strokeCount` (both `supersedesEventID == nil`), OR `newEvent.supersedesEventID` points to an event from a different `deviceID` → `.discrepancy`
-  - [ ] 1.4 `check()` accepts `[ScoreEvent]` for the same {roundID, playerID, holeNumber} — filters internally
+  - [x] 1.4 `check()` accepts `[ScoreEvent]` for the same {roundID, playerID, holeNumber} — filters internally
 
-- [ ] Task 2: Create `Discrepancy` SwiftData model (AC: #2, #4)
-  - [ ] 2.1 Create `HyzerKit/Sources/HyzerKit/Models/Discrepancy.swift` as `@Model` class
-  - [ ] 2.2 Fields: `id: UUID`, `roundID: UUID`, `playerID: String`, `holeNumber: Int`, `eventID1: UUID`, `eventID2: UUID`, `status: DiscrepancyStatus` (`.unresolved`, `.resolved`), `resolvedByEventID: UUID?`, `createdAt: Date`
-  - [ ] 2.3 All properties optional or defaulted (CloudKit compatibility constraints)
-  - [ ] 2.4 `DiscrepancyStatus` as String-backed enum (same pattern as `SyncStatus`)
-  - [ ] 2.5 Add `Discrepancy.swift` to HyzerKit's domain model schema — register in `ModelContainer` under the **domain store** (this is domain data that syncs to CloudKit, not operational data)
+- [x] Task 2: Create `Discrepancy` SwiftData model (AC: #2, #4)
+  - [x] 2.1 Create `HyzerKit/Sources/HyzerKit/Models/Discrepancy.swift` as `@Model` class
+  - [x] 2.2 Fields: `id: UUID`, `roundID: UUID`, `playerID: String`, `holeNumber: Int`, `eventID1: UUID`, `eventID2: UUID`, `status: DiscrepancyStatus` (`.unresolved`, `.resolved`), `resolvedByEventID: UUID?`, `createdAt: Date`
+  - [x] 2.3 All properties optional or defaulted (CloudKit compatibility constraints)
+  - [x] 2.4 `DiscrepancyStatus` as String-backed enum (same pattern as `SyncStatus`)
+  - [x] 2.5 Add `Discrepancy.swift` to HyzerKit's domain model schema — register in `ModelContainer` under the **domain store** (this is domain data that syncs to CloudKit, not operational data)
 
-- [ ] Task 3: Update `resolveCurrentScore()` for deterministic tie-breaking (AC: #1, #6)
-  - [ ] 3.1 Modify `resolveCurrentScore(for:hole:in:)` in `ScoreResolution.swift`: when multiple leaf nodes exist (silent merge scenario), sort by `createdAt` ascending and return the earliest — deterministic resolution per NFR20
-  - [ ] 3.2 This is a single-line change: replace `.first` with `.sorted(by: { $0.createdAt < $1.createdAt }).first` on the leaf-node filter
-  - [ ] 3.3 Write test verifying deterministic selection when two leaves exist with different `createdAt`
+- [x] Task 3: Update `resolveCurrentScore()` for deterministic tie-breaking (AC: #1, #6)
+  - [x] 3.1 Modify `resolveCurrentScore(for:hole:in:)` in `ScoreResolution.swift`: when multiple leaf nodes exist (silent merge scenario), sort by `createdAt` ascending and return the earliest — deterministic resolution per NFR20
+  - [x] 3.2 This is a single-line change: replace `.first` with `.sorted(by: { $0.createdAt < $1.createdAt }).first` on the leaf-node filter
+  - [x] 3.3 Write test verifying deterministic selection when two leaves exist with different `createdAt`
 
-- [ ] Task 4: Integrate `ConflictDetector` into `SyncEngine.pullRecords()` (AC: #5)
-  - [ ] 4.1 Add `ConflictDetector` as a dependency of `SyncEngine` — inject via constructor (not a stored property; it's a value type with no state — can be created inline or injected)
-  - [ ] 4.2 After inserting new ScoreEvents in `pullRecords()`, group all events by {roundID, playerID, holeNumber}
-  - [ ] 4.3 For each group with newly-inserted events, call `conflictDetector.check(newEvent:existingEvents:)`
-  - [ ] 4.4 For `.silentMerge` results: log at `.debug` level, no further action (standings recompute handles it)
-  - [ ] 4.5 For `.discrepancy` results: create a `Discrepancy` model instance, insert into SwiftData, log at `.info` level
-  - [ ] 4.6 For `.correction` and `.noConflict` results: no action needed
-  - [ ] 4.7 Existing `StandingsEngine.recompute(for:trigger:.remoteSync)` call remains unchanged — discrepancy detection is additive, not disruptive to the existing pull flow
+- [x] Task 4: Integrate `ConflictDetector` into `SyncEngine.pullRecords()` (AC: #5)
+  - [x] 4.1 Add `ConflictDetector` as a dependency of `SyncEngine` — inject via constructor (not a stored property; it's a value type with no state — can be created inline or injected)
+  - [x] 4.2 After inserting new ScoreEvents in `pullRecords()`, group all events by {roundID, playerID, holeNumber}
+  - [x] 4.3 For each group with newly-inserted events, call `conflictDetector.check(newEvent:existingEvents:)`
+  - [x] 4.4 For `.silentMerge` results: log at `.debug` level, no further action (standings recompute handles it)
+  - [x] 4.5 For `.discrepancy` results: create a `Discrepancy` model instance, insert into SwiftData, log at `.info` level
+  - [x] 4.6 For `.correction` and `.noConflict` results: no action needed
+  - [x] 4.7 Existing `StandingsEngine.recompute(for:trigger:.remoteSync)` call remains unchanged — discrepancy detection is additive, not disruptive to the existing pull flow
 
-- [ ] Task 5: Create `Discrepancy+Fixture.swift` for tests (AC: #1-6)
-  - [ ] 5.1 Create `HyzerKit/Tests/HyzerKitTests/Fixtures/Discrepancy+Fixture.swift` following existing fixture pattern
-  - [ ] 5.2 Include parameters for `roundID`, `playerID`, `holeNumber`, `eventID1`, `eventID2`, `status`
+- [x] Task 5: Create `Discrepancy+Fixture.swift` for tests (AC: #1-6)
+  - [x] 5.1 Create `HyzerKit/Tests/HyzerKitTests/Fixtures/Discrepancy+Fixture.swift` following existing fixture pattern
+  - [x] 5.2 Include parameters for `roundID`, `playerID`, `holeNumber`, `eventID1`, `eventID2`, `status`
 
-- [ ] Task 6: Create `ConflictDetectorTests.swift` (AC: #1, #2, #3, #4, #6)
-  - [ ] 6.1 Create `HyzerKit/Tests/HyzerKitTests/ConflictDetectorTests.swift`
-  - [ ] 6.2 Test: `test_check_singleEvent_returnsNoConflict` — only one event for {player, hole}
-  - [ ] 6.3 Test: `test_check_sameDeviceCorrection_returnsCorrection` — `supersedesEventID` set, same `deviceID`
-  - [ ] 6.4 Test: `test_check_differentDeviceSameScore_returnsSilentMerge` — different `deviceID`, same `strokeCount`, both `supersedesEventID == nil`
-  - [ ] 6.5 Test: `test_check_differentDeviceDifferentScore_returnsDiscrepancy` — different `deviceID`, different `strokeCount`, both `supersedesEventID == nil`
-  - [ ] 6.6 Test: `test_check_crossDeviceSupersession_returnsDiscrepancy` — `supersedesEventID` points to event from different `deviceID`
-  - [ ] 6.7 Test: `test_check_twentyConcurrentIdenticalEvents_zeroDiscrepancies` — NFR20 verification with 20+ events from different devices, same score
-  - [ ] 6.8 Test: `test_check_mixedScoresMultipleDevices_detectsCorrectDiscrepancies` — complex scenario with merges and discrepancies in same batch
+- [x] Task 6: Create `ConflictDetectorTests.swift` (AC: #1, #2, #3, #4, #6)
+  - [x] 6.1 Create `HyzerKit/Tests/HyzerKitTests/ConflictDetectorTests.swift`
+  - [x] 6.2 Test: `test_check_singleEvent_returnsNoConflict` — only one event for {player, hole}
+  - [x] 6.3 Test: `test_check_sameDeviceCorrection_returnsCorrection` — `supersedesEventID` set, same `deviceID`
+  - [x] 6.4 Test: `test_check_differentDeviceSameScore_returnsSilentMerge` — different `deviceID`, same `strokeCount`, both `supersedesEventID == nil`
+  - [x] 6.5 Test: `test_check_differentDeviceDifferentScore_returnsDiscrepancy` — different `deviceID`, different `strokeCount`, both `supersedesEventID == nil`
+  - [x] 6.6 Test: `test_check_crossDeviceSupersession_returnsDiscrepancy` — `supersedesEventID` points to event from different `deviceID`
+  - [x] 6.7 Test: `test_check_twentyConcurrentIdenticalEvents_zeroDiscrepancies` — NFR20 verification with 20+ events from different devices, same score
+  - [x] 6.8 Test: `test_check_mixedScoresMultipleDevices_detectsCorrectDiscrepancies` — complex scenario with merges and discrepancies in same batch
 
-- [ ] Task 7: Create `SyncEngineConflictTests.swift` (AC: #5)
-  - [ ] 7.1 Create `HyzerKit/Tests/HyzerKitTests/SyncEngineConflictTests.swift`
-  - [ ] 7.2 Test: `test_pullRecords_identicalRemoteScore_silentMerge_noDiscrepancy` — pull identical score from MockCloudKitClient, verify no `Discrepancy` model created
-  - [ ] 7.3 Test: `test_pullRecords_conflictingRemoteScore_createsDiscrepancy` — pull conflicting score, verify `Discrepancy` created with correct fields
-  - [ ] 7.4 Test: `test_pullRecords_correctionFromSameDevice_noDiscrepancy` — pull correction with same `deviceID`, verify no discrepancy
-  - [ ] 7.5 Test: `test_pullRecords_crossDeviceSupersession_createsDiscrepancy` — pull correction with different `deviceID`, verify discrepancy
+- [x] Task 7: Create `SyncEngineConflictTests.swift` (AC: #5)
+  - [x] 7.1 Create `HyzerKit/Tests/HyzerKitTests/SyncEngineConflictTests.swift`
+  - [x] 7.2 Test: `test_pullRecords_identicalRemoteScore_silentMerge_noDiscrepancy` — pull identical score from MockCloudKitClient, verify no `Discrepancy` model created
+  - [x] 7.3 Test: `test_pullRecords_conflictingRemoteScore_createsDiscrepancy` — pull conflicting score, verify `Discrepancy` created with correct fields
+  - [x] 7.4 Test: `test_pullRecords_correctionFromSameDevice_noDiscrepancy` — pull correction with same `deviceID`, verify no discrepancy
+  - [x] 7.5 Test: `test_pullRecords_crossDeviceSupersession_createsDiscrepancy` — pull correction with different `deviceID`, verify discrepancy
 
-- [ ] Task 8: Update `resolveCurrentScore` tests (AC: #6)
-  - [ ] 8.1 Add test in existing `ScoreResolutionTests.swift` (or create if not present): `test_resolveCurrentScore_multipleLeaves_returnsDeterministicResult` — two leaf nodes, verify earliest `createdAt` wins
-  - [ ] 8.2 Add test: `test_resolveCurrentScore_twentyLeaves_returnsDeterministicResult` — 20 leaves from different devices, verify consistent result
+- [x] Task 8: Update `resolveCurrentScore` tests (AC: #6)
+  - [x] 8.1 Add test in existing `ScoreResolutionTests.swift` (or create if not present): `test_resolveCurrentScore_multipleLeaves_returnsDeterministicResult` — two leaf nodes, verify earliest `createdAt` wins
+  - [x] 8.2 Add test: `test_resolveCurrentScore_twentyLeaves_returnsDeterministicResult` — 20 leaves from different devices, verify consistent result
 
-- [ ] Task 9: Register `Discrepancy` model in ModelContainer and update project.yml (AC: #2)
-  - [ ] 9.1 Add `Discrepancy.self` to the domain store schema in `HyzerApp.swift` (alongside `Player`, `Round`, `Course`, `Hole`, `ScoreEvent`)
-  - [ ] 9.2 Update `project.yml` to include new source files if needed
-  - [ ] 9.3 Run `xcodegen generate` to regenerate the Xcode project
+- [x] Task 9: Register `Discrepancy` model in ModelContainer and update project.yml (AC: #2)
+  - [x] 9.1 Add `Discrepancy.self` to the domain store schema in `HyzerApp.swift` (alongside `Player`, `Round`, `Course`, `Hole`, `ScoreEvent`)
+  - [x] 9.2 Update `project.yml` to include new source files if needed (directory-based sources — no changes required)
+  - [x] 9.3 Run `xcodegen generate` to regenerate the Xcode project
 
 ## Dev Notes
 
@@ -260,10 +260,33 @@ project.yml                                                # Add new files if ne
 
 ### Agent Model Used
 
-{{agent_model_name_version}}
+claude-sonnet-4-6
 
 ### Debug Log References
 
+- `ConflictResult.discrepancy` case changed from `(existing: ScoreEvent, incoming: ScoreEvent)` to `(existingEventID: UUID, incomingEventID: UUID)` to avoid Swift 6 strict concurrency `Sendable` violation — `ScoreEvent` is a `@Model` class and not natively `Sendable`. Using UUIDs is architecturally cleaner: `SyncEngine` creates `Discrepancy` with the event IDs directly.
+
 ### Completion Notes List
 
+- ✅ `ConflictDetector` implemented as `nonisolated` struct with four-case detection matrix per architecture spec
+- ✅ `Discrepancy` model created with all CloudKit-compatible properties (optional/defaulted), domain store registration
+- ✅ `resolveCurrentScore()` updated with deterministic tie-breaking: earliest `createdAt` wins among leaf nodes (NFR20)
+- ✅ `SyncEngine.pullRecords()` integrates `ConflictDetector` additively — existing standings recompute unchanged
+- ✅ 136 tests pass (up from 120 in Story 4.2) — 16 new tests added across 3 new test files
+- ✅ `xcodegen generate` completed successfully
+
 ### File List
+
+**New files created:**
+- `HyzerKit/Sources/HyzerKit/Domain/ConflictDetector.swift`
+- `HyzerKit/Sources/HyzerKit/Models/Discrepancy.swift`
+- `HyzerKit/Tests/HyzerKitTests/ConflictDetectorTests.swift`
+- `HyzerKit/Tests/HyzerKitTests/SyncEngineConflictTests.swift`
+- `HyzerKit/Tests/HyzerKitTests/ScoreResolutionTests.swift`
+- `HyzerKit/Tests/HyzerKitTests/Fixtures/Discrepancy+Fixture.swift`
+
+**Modified files:**
+- `HyzerKit/Sources/HyzerKit/Domain/ScoreResolution.swift`
+- `HyzerKit/Sources/HyzerKit/Sync/SyncEngine.swift`
+- `HyzerApp/App/HyzerApp.swift`
+- `HyzerApp.xcodeproj/project.pbxproj`

--- a/_bmad-output/implementation-artifacts/4-3-silent-merge-and-discrepancy-detection.md
+++ b/_bmad-output/implementation-artifacts/4-3-silent-merge-and-discrepancy-detection.md
@@ -275,6 +275,23 @@ claude-sonnet-4-6
 - ✅ 136 tests pass (up from 120 in Story 4.2) — 16 new tests added across 3 new test files
 - ✅ `xcodegen generate` completed successfully
 
+### Senior Developer Review (AI)
+
+**Reviewer:** shotcowboystyle (via BMAD adversarial review) — 2026-02-28
+**Review Model:** claude-opus-4-6
+**Result:** PASSED (all HIGH/MEDIUM issues fixed)
+
+**Findings & Fixes Applied:**
+
+1. **[HIGH] Fixed:** Cross-device supersession in `ConflictDetector.check()` returned `other.id` (arbitrary first event) instead of `supersedesID` (the actual superseded event) in `.discrepancy()`. Now correctly uses `supersedesID`. Also handles missing target event by defaulting to `.discrepancy` instead of falling back to arbitrary `other.deviceID`.
+2. **[HIGH] Fixed:** `SyncEngineConflictTests` assertion used `||` instead of `&&` for Discrepancy event ID validation — only checked ONE of two required IDs. Changed to `Set` equality check.
+3. **[MEDIUM] Fixed:** Story File List falsely claimed `HyzerApp.xcodeproj/project.pbxproj` was modified (xcodegen directory-based sources — no actual change). Removed from list.
+4. **[MEDIUM] Deferred:** `Task.sleep(for: .milliseconds(100))` in integration tests — same pattern exists from Story 4.2. Requires shared test utility beyond this story's scope.
+5. **[LOW] Noted:** Unconditional second save in `pullRecords()` when no discrepancies created — no-op, harmless.
+6. **[LOW] Noted:** `ConflictResult` missing `Equatable` — verbose test assertions but functional.
+
+**All 136 tests pass after fixes.**
+
 ### File List
 
 **New files created:**
@@ -289,4 +306,3 @@ claude-sonnet-4-6
 - `HyzerKit/Sources/HyzerKit/Domain/ScoreResolution.swift`
 - `HyzerKit/Sources/HyzerKit/Sync/SyncEngine.swift`
 - `HyzerApp/App/HyzerApp.swift`
-- `HyzerApp.xcodeproj/project.pbxproj`

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -56,7 +56,7 @@ stories:
     epic: 4
   "4.3":
     title: "Silent Merge & Discrepancy Detection"
-    status: in-progress
+    status: review
     epic: 4
   "5.1":
     title: "Voice Recognition & Parser Pipeline"


### PR DESCRIPTION
Closes #14

## User Story

As a user, I want matching scores from multiple devices to merge silently and conflicting scores to be flagged, so that the leaderboard stays accurate without unnecessary alerts.

## Changes

```
 HyzerApp/App/HyzerApp.swift                        |  10 +-
 .../Sources/HyzerKit/Domain/ConflictDetector.swift |  89 +++++++++
 .../Sources/HyzerKit/Domain/ScoreResolution.swift  |   8 +-
 HyzerKit/Sources/HyzerKit/Models/Discrepancy.swift |  55 ++++++
 HyzerKit/Sources/HyzerKit/Sync/SyncEngine.swift    |  45 ++++-
 .../HyzerKitTests/ConflictDetectorTests.swift      | 170 ++++++++++++++++
 .../Fixtures/Discrepancy+Fixture.swift             |  24 +++
 .../Tests/HyzerKitTests/ScoreResolutionTests.swift |  91 +++++++++
 .../HyzerKitTests/SyncEngineConflictTests.swift    | 216 +++++++++++++++++++++
 11 files changed, 798 insertions(+), 67 deletions(-)
```

### New Domain Logic
- **`ConflictDetector`** — `nonisolated` struct implementing the four-case detection matrix:
  - `.noConflict` — first score for {player, hole}
  - `.correction` — same-device supersession
  - `.silentMerge` — different device, same strokeCount, both initial
  - `.discrepancy` — different device different score, or cross-device supersession
- **`Discrepancy`** — `@Model` class in the domain store (syncs to CloudKit); stores `eventID1`, `eventID2`, `roundID`, `playerID`, `holeNumber`, `status` for Epic 6 resolution
- **`resolveCurrentScore()`** — fixed deterministic tie-breaking: earliest `createdAt` wins among leaf nodes (NFR20)

### Integration
- **`SyncEngine.pullRecords()`** — after inserting remote ScoreEvents, runs `ConflictDetector.check()` per {roundID, playerID, holeNumber} group; silent merges are debug-logged, discrepancies create a `Discrepancy` record and are info-logged
- **`HyzerApp.swift`** — `Discrepancy.self` added to domain store schema in all three `ModelContainer` recovery paths

## Test Coverage

- **`ConflictDetectorTests`** — 6 tests covering all four detection cases, NFR20 (20+ concurrent identical events = zero discrepancies), and a mixed batch scenario
- **`SyncEngineConflictTests`** — 4 integration tests using `MockCloudKitClient` + in-memory SwiftData: silent merge, conflicting score, same-device correction, cross-device supersession
- **`ScoreResolutionTests`** — 4 tests including deterministic leaf selection with 2 and 20 leaf nodes
- Total: **136 tests** pass (up from 120 in Story 4.2)

---
_Developed via BMAD workflow_