### PR TITLE
Story 5.1: Voice Recognition & Parser Pipeline

### DIFF
--- a/HyzerApp.xcodeproj/project.pbxproj
+++ b/HyzerApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		04E543641263753B01CC98B2 /* RoundSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63536A325A8FD3F5E743896 /* RoundSummaryView.swift */; };
 		079960697F1DB732A0FE5870 /* ScorecardContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4619B6CC10DE1F2616549B7E /* ScorecardContainerView.swift */; };
 		0F9A0D4BCB7C9197C852E4D5 /* CourseEditorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A20DA3AF53A4644D429F /* CourseEditorViewModelTests.swift */; };
+		142C71682F24A3434B25C712 /* VoiceRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 751B4A4FAE27078A43BE3A3F /* VoiceRecognitionService.swift */; };
 		1B216ACD7E371E7C974AA480 /* RoundSetupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B4334F9A1744E9A0EA28B0 /* RoundSetupViewModelTests.swift */; };
 		1FD1D4A3ADFD21C470D1189F /* LeaderboardPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E77E4E336452EAE570A4531 /* LeaderboardPillView.swift */; };
 		264848715C0438CE283A1429 /* ScorecardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0271AF96B676CB2280840B30 /* ScorecardViewModel.swift */; };
@@ -98,6 +99,7 @@
 		54DB32460AB85326B67BFFE3 /* ScorecardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScorecardViewModelTests.swift; sourceTree = "<group>"; };
 		6A5193A54F5E0E9F5E5BA893 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6E77E4E336452EAE570A4531 /* LeaderboardPillView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardPillView.swift; sourceTree = "<group>"; };
+		751B4A4FAE27078A43BE3A3F /* VoiceRecognitionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecognitionService.swift; sourceTree = "<group>"; };
 		800D115E8B8669538227512F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		89EC7DCB75B63B758D964D2B /* CourseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailView.swift; sourceTree = "<group>"; };
 		902F00FF404EE9264C780629 /* CourseEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseEditorView.swift; sourceTree = "<group>"; };
@@ -333,6 +335,7 @@
 				99BEC27ED6A658066DE3B9F9 /* LiveCloudKitClient.swift */,
 				41F4A3FDA72AE73321E44E1B /* LiveICloudIdentityProvider.swift */,
 				D0EAF2CE8A78AA9A463585BB /* LiveNetworkMonitor.swift */,
+				751B4A4FAE27078A43BE3A3F /* VoiceRecognitionService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -540,6 +543,7 @@
 				079960697F1DB732A0FE5870 /* ScorecardContainerView.swift in Sources */,
 				264848715C0438CE283A1429 /* ScorecardViewModel.swift in Sources */,
 				64457CFB0B3C54CCACB441C1 /* SyncIndicatorView.swift in Sources */,
+				142C71682F24A3434B25C712 /* VoiceRecognitionService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HyzerApp/App/Info.plist
+++ b/HyzerApp/App/Info.plist
@@ -18,6 +18,10 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>HyzerApp uses the microphone to hear player names and scores for hands-free scoring.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>HyzerApp uses speech recognition to convert spoken scores into game entries. All processing happens on-device.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/HyzerApp/Services/VoiceRecognitionService.swift
+++ b/HyzerApp/Services/VoiceRecognitionService.swift
@@ -53,10 +53,12 @@ public final class VoiceRecognitionService {
                 return
             }
 
-            recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
-                guard let self else { return }
+            var hasResumed = false
+            recognitionTask = recognizer.recognitionTask(with: request) { [self] result, error in
+                guard !hasResumed else { return }
 
                 if let error = error {
+                    hasResumed = true
                     self.stopAudioEngine()
                     let nsError = error as NSError
                     if nsError.code == 1110 {
@@ -68,6 +70,7 @@ public final class VoiceRecognitionService {
                 }
 
                 guard let result, result.isFinal else { return }
+                hasResumed = true
                 self.stopAudioEngine()
                 let transcript = result.bestTranscription.formattedString
                 if transcript.isEmpty {
@@ -101,6 +104,6 @@ public final class VoiceRecognitionService {
                 continuation.resume(returning: status)
             }
         }
-        guard speechStatus == .authorized else { throw VoiceParseError.microphonePermissionDenied }
+        guard speechStatus == .authorized else { throw VoiceParseError.recognitionUnavailable }
     }
 }

--- a/HyzerApp/Services/VoiceRecognitionService.swift
+++ b/HyzerApp/Services/VoiceRecognitionService.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Speech
+import HyzerKit
+
+/// Wraps `SFSpeechRecognizer` to provide on-device speech recognition for voice score entry.
+///
+/// Lives exclusively in `HyzerApp/Services/` — never in HyzerKit — because the `Speech` framework
+/// is not available on watchOS/macOS (NFR: platform isolation constraint).
+///
+/// `@MainActor` — interacts with UI permission prompts and AVAudioEngine.
+@MainActor
+public final class VoiceRecognitionService {
+
+    private let speechRecognizer: SFSpeechRecognizer?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private let audioEngine = AVAudioEngine()
+
+    public init() {
+        let recognizer = SFSpeechRecognizer()
+        recognizer?.defaultTaskHint = .dictation
+        self.speechRecognizer = recognizer
+    }
+
+    /// Requests microphone and speech recognition permissions, then records and transcribes speech.
+    ///
+    /// - Returns: The transcribed string from on-device recognition.
+    /// - Throws: `VoiceParseError.microphonePermissionDenied` if mic access denied.
+    ///           `VoiceParseError.recognitionUnavailable` if speech recognition unavailable.
+    ///           `VoiceParseError.noSpeechDetected` if no speech was captured.
+    public func recognize() async throws -> String {
+        try await requestPermissions()
+
+        guard let recognizer = speechRecognizer, recognizer.isAvailable else {
+            throw VoiceParseError.recognitionUnavailable
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let request = SFSpeechAudioBufferRecognitionRequest()
+            request.requiresOnDeviceRecognition = true
+            request.shouldReportPartialResults = false
+
+            let inputNode = audioEngine.inputNode
+            let format = inputNode.outputFormat(forBus: 0)
+            inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+                request.append(buffer)
+            }
+
+            audioEngine.prepare()
+            do {
+                try audioEngine.start()
+            } catch {
+                continuation.resume(throwing: VoiceParseError.recognitionUnavailable)
+                return
+            }
+
+            recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+                guard let self else { return }
+
+                if let error = error {
+                    self.stopAudioEngine()
+                    let nsError = error as NSError
+                    if nsError.code == 1110 {
+                        continuation.resume(throwing: VoiceParseError.noSpeechDetected)
+                    } else {
+                        continuation.resume(throwing: VoiceParseError.recognitionUnavailable)
+                    }
+                    return
+                }
+
+                guard let result, result.isFinal else { return }
+                self.stopAudioEngine()
+                let transcript = result.bestTranscription.formattedString
+                if transcript.isEmpty {
+                    continuation.resume(throwing: VoiceParseError.noSpeechDetected)
+                } else {
+                    continuation.resume(returning: transcript)
+                }
+            }
+        }
+    }
+
+    private func stopAudioEngine() {
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        recognitionTask?.cancel()
+        recognitionTask = nil
+    }
+
+    // MARK: - Permissions
+
+    private func requestPermissions() async throws {
+        let micStatus = await withCheckedContinuation { continuation in
+            AVAudioApplication.requestRecordPermission { granted in
+                continuation.resume(returning: granted)
+            }
+        }
+        guard micStatus else { throw VoiceParseError.microphonePermissionDenied }
+
+        let speechStatus = await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+        guard speechStatus == .authorized else { throw VoiceParseError.microphonePermissionDenied }
+    }
+}

--- a/HyzerKit/Sources/HyzerKit/Voice/FuzzyNameMatcher.swift
+++ b/HyzerKit/Sources/HyzerKit/Voice/FuzzyNameMatcher.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Resolves name tokens against a known player list using deterministic matching strategies.
+///
+/// `nonisolated` struct — stateless after init, `Sendable`, no actor isolation required.
+/// Takes a flattened player representation to avoid any SwiftData dependency.
+public struct FuzzyNameMatcher: Sendable {
+
+    /// The result of attempting to match a name token against the player list.
+    public enum MatchResult: Sendable {
+        /// Exactly one player matched the token.
+        case matched(playerID: String, displayName: String)
+        /// Multiple players are plausible matches (similarity 50–80%).
+        case ambiguous(candidates: [(playerID: String, displayName: String)])
+        /// No player matched above the minimum threshold (<50% similarity).
+        case unmatched
+    }
+
+    private struct Entry: Sendable {
+        let playerID: String
+        let displayName: String
+        let aliases: [String]
+    }
+
+    private let players: [Entry]
+
+    /// Initializer takes a flattened player list — no SwiftData dependency.
+    public init(players: [(playerID: String, displayName: String, aliases: [String])]) {
+        self.players = players.map { Entry(playerID: $0.playerID, displayName: $0.displayName, aliases: $0.aliases) }
+    }
+
+    /// Resolves a name token to a known player.
+    ///
+    /// Matching priority:
+    /// 1. Alias exact match (case-insensitive)
+    /// 2. Display name exact match (case-insensitive)
+    /// 3. Display name prefix (unique prefix among all players)
+    /// 4. Levenshtein similarity: ≥0.8 → accept; 0.5–0.8 → ambiguous; <0.5 → unmatched
+    public func match(token: String) -> MatchResult {
+        let lower = token.lowercased()
+
+        // 1. Alias exact match
+        let aliasMatches = players.filter { $0.aliases.contains { $0.lowercased() == lower } }
+        if aliasMatches.count == 1 { return .matched(playerID: aliasMatches[0].playerID, displayName: aliasMatches[0].displayName) }
+        if aliasMatches.count > 1 { return .ambiguous(candidates: aliasMatches.map { ($0.playerID, $0.displayName) }) }
+
+        // 2. Display name exact match
+        let displayMatches = players.filter { $0.displayName.lowercased() == lower }
+        if displayMatches.count == 1 { return .matched(playerID: displayMatches[0].playerID, displayName: displayMatches[0].displayName) }
+        if displayMatches.count > 1 { return .ambiguous(candidates: displayMatches.map { ($0.playerID, $0.displayName) }) }
+
+        // 3. Display name unique prefix
+        let prefixMatches = players.filter { $0.displayName.lowercased().hasPrefix(lower) }
+        if prefixMatches.count == 1 { return .matched(playerID: prefixMatches[0].playerID, displayName: prefixMatches[0].displayName) }
+        if prefixMatches.count > 1 { return .ambiguous(candidates: prefixMatches.map { ($0.playerID, $0.displayName) }) }
+
+        // 4. Levenshtein distance fallback
+        return levenshteinMatch(lower: lower)
+    }
+
+    // MARK: - Levenshtein Fallback
+
+    private func levenshteinMatch(lower: String) -> MatchResult {
+        var acceptMatches: [(playerID: String, displayName: String, similarity: Double)] = []
+        var ambiguousMatches: [(playerID: String, displayName: String)] = []
+
+        for player in players {
+            let name = player.displayName.lowercased()
+            let dist = levenshteinDistance(lower, name)
+            let maxLen = max(lower.count, name.count)
+            guard maxLen > 0 else { continue }
+            let similarity = 1.0 - Double(dist) / Double(maxLen)
+
+            if similarity >= 0.8 {
+                acceptMatches.append((player.playerID, player.displayName, similarity))
+            } else if similarity >= 0.5 {
+                ambiguousMatches.append((player.playerID, player.displayName))
+            }
+        }
+
+        if acceptMatches.count == 1 { return .matched(playerID: acceptMatches[0].playerID, displayName: acceptMatches[0].displayName) }
+        if acceptMatches.count > 1 { return .ambiguous(candidates: acceptMatches.map { ($0.playerID, $0.displayName) }) }
+        if !ambiguousMatches.isEmpty { return .ambiguous(candidates: ambiguousMatches) }
+
+        return .unmatched
+    }
+
+    private func levenshteinDistance(_ a: String, _ b: String) -> Int {
+        let aChars = Array(a)
+        let bChars = Array(b)
+        let aLen = aChars.count
+        let bLen = bChars.count
+        if aLen == 0 { return bLen }
+        if bLen == 0 { return aLen }
+
+        var prev = Array(0...bLen)
+        for i in 1...aLen {
+            var curr = [Int](repeating: 0, count: bLen + 1)
+            curr[0] = i
+            for j in 1...bLen {
+                curr[j] = aChars[i - 1] == bChars[j - 1] ? prev[j - 1] : 1 + min(prev[j - 1], prev[j], curr[j - 1])
+            }
+            prev = curr
+        }
+        return prev[bLen]
+    }
+}

--- a/HyzerKit/Sources/HyzerKit/Voice/TokenClassifier.swift
+++ b/HyzerKit/Sources/HyzerKit/Voice/TokenClassifier.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Classifies individual string tokens from a voice transcript.
+///
+/// `nonisolated` struct — stateless, `Sendable`, no actor isolation required.
+public struct TokenClassifier: Sendable {
+
+    /// Broad number-word map: includes out-of-range words so they can be rejected as noise
+    /// rather than incorrectly classified as player names.
+    private static let wordToNumber: [String: Int] = [
+        "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
+        "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10,
+        "eleven": 11, "twelve": 12, "thirteen": 13, "fourteen": 14, "fifteen": 15,
+        "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19, "twenty": 20,
+        "thirty": 30, "forty": 40, "fifty": 50, "sixty": 60, "seventy": 70,
+        "eighty": 80, "ninety": 90, "hundred": 100, "zero": 0
+    ]
+
+    public init() {}
+
+    /// Classifies a single string token into `.name`, `.number`, or `.noise`.
+    ///
+    /// - `.number(Int)`: digit string or word number in range 1–10
+    /// - `.name(String)`: purely alphabetic token (not a word number)
+    /// - `.noise(String)`: everything else, or out-of-range numbers
+    public func classify(raw: String) -> Token {
+        let cleaned = raw.trimmingCharacters(in: .punctuationCharacters).lowercased()
+        guard !cleaned.isEmpty else { return .noise(raw) }
+
+        // Digit string
+        if let int = Int(cleaned) {
+            return (1...10).contains(int) ? .number(int) : .noise(raw)
+        }
+
+        // Word number — range check: 1–10 valid, outside range → noise (not a player name)
+        if let int = Self.wordToNumber[cleaned] {
+            return (1...10).contains(int) ? .number(int) : .noise(raw)
+        }
+
+        // Purely alphabetic → name candidate
+        let isAlphabetic = cleaned.unicodeScalars.allSatisfy { CharacterSet.letters.contains($0) }
+        if isAlphabetic {
+            return .name(raw.trimmingCharacters(in: .punctuationCharacters))
+        }
+
+        return .noise(raw)
+    }
+}

--- a/HyzerKit/Sources/HyzerKit/Voice/VoiceParseError.swift
+++ b/HyzerKit/Sources/HyzerKit/Voice/VoiceParseError.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Errors thrown by `VoiceRecognitionService` during the speech recognition lifecycle.
+public enum VoiceParseError: Error, Sendable {
+    /// The user denied microphone access.
+    case microphonePermissionDenied
+    /// On-device speech recognition is unavailable (unsupported locale or model not downloaded).
+    case recognitionUnavailable
+    /// The speech recognizer produced no usable speech within the recognition window.
+    case noSpeechDetected
+}

--- a/HyzerKit/Sources/HyzerKit/Voice/VoiceParseResult.swift
+++ b/HyzerKit/Sources/HyzerKit/Voice/VoiceParseResult.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// The result of parsing a voice transcript against a known player list.
+public enum VoiceParseResult: Sendable {
+    /// All player names in the transcript were resolved and paired with stroke counts.
+    case success([ScoreCandidate])
+    /// Some names were resolved; others could not be matched to known players.
+    case partial(recognized: [ScoreCandidate], unresolved: [String])
+    /// No names could be resolved from the transcript.
+    case failed(transcript: String)
+}
+
+/// A successfully resolved player–score pair produced by `VoiceParser`.
+public struct ScoreCandidate: Sendable, Equatable {
+    public let playerID: String
+    public let displayName: String
+    public let strokeCount: Int
+
+    public init(playerID: String, displayName: String, strokeCount: Int) {
+        self.playerID = playerID
+        self.displayName = displayName
+        self.strokeCount = strokeCount
+    }
+}
+
+/// A classified token from a voice transcript.
+public enum Token: Sendable, Equatable {
+    /// A token classified as a player name fragment.
+    case name(String)
+    /// A token classified as a stroke count (1–10).
+    case number(Int)
+    /// A token that could not be meaningfully classified.
+    case noise(String)
+}

--- a/HyzerKit/Sources/HyzerKit/Voice/VoiceParser.swift
+++ b/HyzerKit/Sources/HyzerKit/Voice/VoiceParser.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Input type for `VoiceParser` — minimal player representation with no SwiftData dependency.
+public struct VoicePlayerEntry: Sendable {
+    public let playerID: String
+    public let displayName: String
+    public let aliases: [String]
+
+    public init(playerID: String, displayName: String, aliases: [String]) {
+        self.playerID = playerID
+        self.displayName = displayName
+        self.aliases = aliases
+    }
+}
+
+/// Parses a voice transcript into player–score pairs via a tokenize → classify → assemble pipeline.
+///
+/// `nonisolated` struct — stateless, `Sendable`, no platform imports (no Speech framework dependency).
+/// Callable from any isolation context without `await`.
+public struct VoiceParser: Sendable {
+
+    private let classifier = TokenClassifier()
+
+    public init() {}
+
+    /// Parses a spoken transcript into a `VoiceParseResult`.
+    ///
+    /// Pipeline:
+    /// 1. Tokenize: split by whitespace and commas → `[String]`
+    /// 2. Classify: each token → `.name`, `.number`, or `.noise`
+    /// 3. Assemble: pair each `.name` with the next `.number` in sequence
+    /// 4. Match: resolve name fragments to known players via `FuzzyNameMatcher`
+    ///
+    /// Subset scoring is valid — "Jake 4" alone is accepted even in a multi-player round.
+    ///
+    /// - Parameters:
+    ///   - transcript: The raw string from speech recognition.
+    ///   - players: The known player list for this round.
+    /// - Returns: `.success`, `.partial`, or `.failed`.
+    public func parse(transcript: String, players: [VoicePlayerEntry]) -> VoiceParseResult {
+        let matcher = FuzzyNameMatcher(players: players.map { ($0.playerID, $0.displayName, $0.aliases) })
+        let rawTokens = tokenize(transcript)
+        let classified = rawTokens.map { classifier.classify(raw: $0) }
+        let pairs = assemble(classified: classified)
+
+        guard !pairs.isEmpty else { return .failed(transcript: transcript) }
+
+        var recognized: [ScoreCandidate] = []
+        var unresolved: [String] = []
+
+        for (nameToken, strokeCount) in pairs {
+            switch matcher.match(token: nameToken) {
+            case .matched(let playerID, let displayName):
+                recognized.append(ScoreCandidate(playerID: playerID, displayName: displayName, strokeCount: strokeCount))
+            case .ambiguous, .unmatched:
+                unresolved.append(nameToken)
+            }
+        }
+
+        if recognized.isEmpty { return .failed(transcript: transcript) }
+        if unresolved.isEmpty { return .success(recognized) }
+        return .partial(recognized: recognized, unresolved: unresolved)
+    }
+
+    // MARK: - Pipeline: Tokenize
+
+    private func tokenize(_ transcript: String) -> [String] {
+        let separators = CharacterSet.whitespaces.union(CharacterSet(charactersIn: ","))
+        return transcript
+            .components(separatedBy: separators)
+            .map { $0.trimmingCharacters(in: .punctuationCharacters) }
+            .filter { !$0.isEmpty }
+    }
+
+    // MARK: - Pipeline: Assemble name-number pairs
+
+    /// Pairs each `.name` token with the next `.number` token that follows it.
+    /// Names with no following number are silently skipped.
+    private func assemble(classified: [Token]) -> [(name: String, strokeCount: Int)] {
+        var pairs: [(name: String, strokeCount: Int)] = []
+        var i = 0
+
+        while i < classified.count {
+            guard case .name(let nameToken) = classified[i] else { i += 1; continue }
+
+            var j = i + 1
+            while j < classified.count {
+                if case .number(let count) = classified[j] {
+                    pairs.append((name: nameToken, strokeCount: count))
+                    i = j + 1
+                    break
+                } else if case .noise = classified[j] {
+                    j += 1
+                } else {
+                    // Another name token — no number found for current name
+                    i = j
+                    break
+                }
+            }
+            if j >= classified.count { i = j }
+        }
+
+        return pairs
+    }
+}

--- a/HyzerKit/Tests/HyzerKitTests/Integration/VoiceToStandingsIntegrationTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/Integration/VoiceToStandingsIntegrationTests.swift
@@ -1,0 +1,187 @@
+import Testing
+import SwiftData
+import Foundation
+@testable import HyzerKit
+
+/// Integration test: voice transcript string → VoiceParser → ScoreEvents → StandingsEngine standings.
+///
+/// No SFSpeechRecognizer used — tests the parser-to-standings pipeline only (AC2, AC4).
+@Suite("VoiceToStandings Integration")
+@MainActor
+struct VoiceToStandingsIntegrationTests {
+
+    // MARK: - Setup helpers
+
+    private func makeContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    private func makeRound(
+        in context: ModelContext,
+        playerIDs: [String],
+        holeCount: Int = 9,
+        parPerHole: Int = 3
+    ) throws -> Round {
+        let course = Course(name: "Test Course", holeCount: holeCount, isSeeded: false)
+        context.insert(course)
+
+        for n in 1...holeCount {
+            context.insert(Hole(courseID: course.id, number: n, par: parPerHole))
+        }
+
+        let round = Round(
+            courseID: course.id,
+            organizerID: UUID(),
+            playerIDs: playerIDs,
+            guestNames: [],
+            holeCount: holeCount
+        )
+        context.insert(round)
+        try context.save()
+        return round
+    }
+
+    // MARK: - AC2, AC4: Full voice-to-standings pipeline
+
+    @Test("transcript Mike 3 Jake 4 Sarah 2 produces correct standings")
+    func test_voiceToStandings_threePlayerTranscript_correctStandings() throws {
+        // Given: three players in the round
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let p1ID = UUID()
+        let p2ID = UUID()
+        let p3ID = UUID()
+
+        let michael = Player(displayName: "Michael")
+        michael.id = p1ID
+        michael.aliases = ["Mike"]
+        let jake = Player(displayName: "Jake")
+        jake.id = p2ID
+        let sarah = Player(displayName: "Sarah")
+        sarah.id = p3ID
+
+        context.insert(michael)
+        context.insert(jake)
+        context.insert(sarah)
+
+        let playerIDStrs = [p1ID.uuidString, p2ID.uuidString, p3ID.uuidString]
+        let round = try makeRound(in: context, playerIDs: playerIDStrs, holeCount: 9, parPerHole: 3)
+
+        // When: voice transcript is parsed (no SFSpeechRecognizer — pure pipeline test)
+        let parser = VoiceParser()
+        let voicePlayers = [
+            VoicePlayerEntry(playerID: p1ID.uuidString, displayName: "Michael", aliases: ["Mike"]),
+            VoicePlayerEntry(playerID: p2ID.uuidString, displayName: "Jake", aliases: []),
+            VoicePlayerEntry(playerID: p3ID.uuidString, displayName: "Sarah", aliases: [])
+        ]
+        let result = parser.parse(transcript: "Mike 3, Jake 4, Sarah 2", players: voicePlayers)
+
+        // Assert parse result
+        guard case .success(let candidates) = result else {
+            Issue.record("Expected .success from VoiceParser, got \(result)")
+            return
+        }
+        #expect(candidates.count == 3)
+
+        // Create ScoreEvents via ScoringService (same path as tap scoring)
+        let scoringService = ScoringService(modelContext: context, deviceID: "voice-device")
+        let reporterID = p1ID
+        for candidate in candidates {
+            try scoringService.createScoreEvent(
+                roundID: round.id,
+                holeNumber: 1,
+                playerID: candidate.playerID,
+                strokeCount: candidate.strokeCount,
+                reportedByPlayerID: reporterID
+            )
+        }
+
+        // Trigger standings recomputation
+        let engine = StandingsEngine(modelContext: context)
+        engine.recompute(for: round.id, trigger: .localScore)
+        let standings = engine.currentStandings
+
+        // Then: three players have standings
+        #expect(standings.count == 3)
+
+        let byID = Dictionary(uniqueKeysWithValues: standings.map { ($0.playerID, $0) })
+
+        // Mike (Michael) scored 3 on par-3 → E (0)
+        #expect(byID[p1ID.uuidString]?.totalStrokes == 3)
+        #expect(byID[p1ID.uuidString]?.scoreRelativeToPar == 0)
+
+        // Jake scored 4 on par-3 → +1
+        #expect(byID[p2ID.uuidString]?.totalStrokes == 4)
+        #expect(byID[p2ID.uuidString]?.scoreRelativeToPar == 1)
+
+        // Sarah scored 2 on par-3 → -1 (best)
+        #expect(byID[p3ID.uuidString]?.totalStrokes == 2)
+        #expect(byID[p3ID.uuidString]?.scoreRelativeToPar == -1)
+
+        // Sarah should be ranked first (lowest score)
+        #expect(byID[p3ID.uuidString]?.position == 1)
+    }
+
+    @Test("subset voice scoring Jake 4 only updates Jake standings")
+    func test_voiceToStandings_subsetScoring_onlyJakeUpdated() throws {
+        // Given: two players
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let p1ID = UUID()
+        let p2ID = UUID()
+
+        let jake = Player(displayName: "Jake")
+        jake.id = p1ID
+        let sarah = Player(displayName: "Sarah")
+        sarah.id = p2ID
+
+        context.insert(jake)
+        context.insert(sarah)
+
+        let round = try makeRound(
+            in: context,
+            playerIDs: [p1ID.uuidString, p2ID.uuidString],
+            holeCount: 9,
+            parPerHole: 3
+        )
+
+        // When: only Jake speaks his score
+        let parser = VoiceParser()
+        let voicePlayers = [
+            VoicePlayerEntry(playerID: p1ID.uuidString, displayName: "Jake", aliases: []),
+            VoicePlayerEntry(playerID: p2ID.uuidString, displayName: "Sarah", aliases: [])
+        ]
+        let result = parser.parse(transcript: "Jake 4", players: voicePlayers)
+
+        guard case .success(let candidates) = result else {
+            Issue.record("Expected .success for subset scoring, got \(result)")
+            return
+        }
+        #expect(candidates.count == 1)
+        #expect(candidates[0].playerID == p1ID.uuidString)
+
+        let service = ScoringService(modelContext: context, deviceID: "voice-device")
+        try service.createScoreEvent(
+            roundID: round.id,
+            holeNumber: 1,
+            playerID: candidates[0].playerID,
+            strokeCount: candidates[0].strokeCount,
+            reportedByPlayerID: p1ID
+        )
+
+        let engine = StandingsEngine(modelContext: context)
+        engine.recompute(for: round.id, trigger: .localScore)
+        let standings = engine.currentStandings
+
+        // Then: only Jake has holesPlayed > 0
+        let byID = Dictionary(uniqueKeysWithValues: standings.map { ($0.playerID, $0) })
+        #expect(byID[p1ID.uuidString]?.holesPlayed == 1)
+        #expect(byID[p1ID.uuidString]?.totalStrokes == 4)
+        #expect(byID[p2ID.uuidString]?.holesPlayed == 0)
+    }
+}

--- a/HyzerKit/Tests/HyzerKitTests/Voice/FuzzyNameMatcherTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/Voice/FuzzyNameMatcherTests.swift
@@ -1,0 +1,157 @@
+import Testing
+import Foundation
+@testable import HyzerKit
+
+@Suite("FuzzyNameMatcher")
+struct FuzzyNameMatcherTests {
+
+    // MARK: - Alias map lookup
+
+    @Test("alias exact match case-insensitive returns matched")
+    func test_match_aliasExact_returnsMatched() {
+        // Given: Michael has alias "Mike"
+        let matcher = FuzzyNameMatcher(players: [
+            (playerID: "p1", displayName: "Michael", aliases: ["Mike", "Mikey"])
+        ])
+
+        // When
+        let result = matcher.match(token: "mike")
+
+        // Then
+        if case .matched(let id, let name) = result {
+            #expect(id == "p1")
+            #expect(name == "Michael")
+        } else {
+            Issue.record("Expected .matched, got \(result)")
+        }
+    }
+
+    @Test("alias match is case-insensitive for mixed-case input")
+    func test_match_aliasExactMixedCase_returnsMatched() {
+        // Given
+        let matcher = FuzzyNameMatcher(players: [
+            (playerID: "p2", displayName: "Sarah", aliases: ["Saz", "Sally"])
+        ])
+
+        // When
+        let result = matcher.match(token: "SAZ")
+
+        // Then
+        if case .matched(let id, _) = result {
+            #expect(id == "p2")
+        } else {
+            Issue.record("Expected .matched for alias SAZ, got \(result)")
+        }
+    }
+
+    // MARK: - Display name exact match
+
+    @Test("display name exact match returns matched")
+    func test_match_displayNameExact_returnsMatched() {
+        // Given
+        let matcher = FuzzyNameMatcher(players: [
+            (playerID: "p1", displayName: "Jake", aliases: [])
+        ])
+
+        // When
+        let result = matcher.match(token: "Jake")
+
+        // Then
+        if case .matched(let id, _) = result {
+            #expect(id == "p1")
+        } else {
+            Issue.record("Expected .matched for Jake, got \(result)")
+        }
+    }
+
+    // MARK: - Display name prefix
+
+    @Test("unique prefix returns matched")
+    func test_match_uniquePrefix_returnsMatched() {
+        // Given: "Michael" is the only player whose name starts with "Mic"
+        let matcher = FuzzyNameMatcher(players: [
+            (playerID: "p1", displayName: "Michael", aliases: []),
+            (playerID: "p2", displayName: "Jake", aliases: [])
+        ])
+
+        // When
+        let result = matcher.match(token: "Mic")
+
+        // Then: "Mic" uniquely prefixes "Michael"
+        if case .matched(let id, _) = result {
+            #expect(id == "p1")
+        } else {
+            Issue.record("Expected .matched for unique prefix Mic, got \(result)")
+        }
+    }
+
+    @Test("ambiguous prefix returns ambiguous")
+    func test_match_ambiguousPrefix_returnsAmbiguous() {
+        // Given: Both Mike and Michelle start with "Mi"
+        let matcher = FuzzyNameMatcher(players: [
+            (playerID: "p1", displayName: "Mike", aliases: []),
+            (playerID: "p2", displayName: "Michelle", aliases: [])
+        ])
+
+        // When
+        let result = matcher.match(token: "Mi")
+
+        // Then
+        if case .ambiguous = result { } else {
+            Issue.record("Expected .ambiguous for shared prefix Mi, got \(result)")
+        }
+    }
+
+    // MARK: - Levenshtein distance
+
+    @Test("high similarity (>=80%) returns matched")
+    func test_match_highSimilarity_returnsMatched() {
+        // Given: "Jakee" has similarity 4/5 = 80% to "Jakee" vs "Jake" (1 deletion = 1/5 = 80% sim)
+        // Actually "Jakes" vs "Jake": distance=1, maxLen=5, similarity=0.8 → accept
+        let matcher = FuzzyNameMatcher(players: [
+            (playerID: "p1", displayName: "Jake", aliases: [])
+        ])
+
+        // When: "Jakes" is 80% similar to "Jake" (1 char diff out of 5)
+        let result = matcher.match(token: "Jakes")
+
+        // Then: 1 - 1/5 = 0.8 → accepted
+        if case .matched(let id, _) = result {
+            #expect(id == "p1")
+        } else {
+            Issue.record("Expected .matched for Jakes~Jake (80% sim), got \(result)")
+        }
+    }
+
+    @Test("low similarity (<50%) returns unmatched")
+    func test_match_lowSimilarity_returnsUnmatched() {
+        // Given
+        let matcher = FuzzyNameMatcher(players: [
+            (playerID: "p1", displayName: "Jake", aliases: [])
+        ])
+
+        // When: completely unrelated token
+        let result = matcher.match(token: "xyz")
+
+        // Then
+        if case .unmatched = result { } else {
+            Issue.record("Expected .unmatched for xyz vs Jake, got \(result)")
+        }
+    }
+
+    // MARK: - No players
+
+    @Test("empty player list returns unmatched")
+    func test_match_emptyPlayerList_returnsUnmatched() {
+        // Given
+        let matcher = FuzzyNameMatcher(players: [])
+
+        // When
+        let result = matcher.match(token: "anyone")
+
+        // Then
+        if case .unmatched = result { } else {
+            Issue.record("Expected .unmatched for empty player list, got \(result)")
+        }
+    }
+}

--- a/HyzerKit/Tests/HyzerKitTests/Voice/FuzzyNameMatcherTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/Voice/FuzzyNameMatcherTests.swift
@@ -123,6 +123,25 @@ struct FuzzyNameMatcherTests {
         }
     }
 
+    @Test("medium similarity (50-80%) returns ambiguous via Levenshtein")
+    func test_match_mediumSimilarity_returnsAmbiguous() {
+        // Given: "Jako" vs "Jake" → distance=1, maxLen=4, similarity=0.75 → ambiguous (50-80%)
+        let matcher = FuzzyNameMatcher(players: [
+            (playerID: "p1", displayName: "Jake", aliases: [])
+        ])
+
+        // When
+        let result = matcher.match(token: "Jako")
+
+        // Then: 75% similarity falls in ambiguous range
+        if case .ambiguous(let candidates) = result {
+            #expect(candidates.count == 1)
+            #expect(candidates[0].playerID == "p1")
+        } else {
+            Issue.record("Expected .ambiguous for Jako~Jake (75% sim), got \(result)")
+        }
+    }
+
     @Test("low similarity (<50%) returns unmatched")
     func test_match_lowSimilarity_returnsUnmatched() {
         // Given

--- a/HyzerKit/Tests/HyzerKitTests/Voice/TokenClassifierTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/Voice/TokenClassifierTests.swift
@@ -1,0 +1,136 @@
+import Testing
+import Foundation
+@testable import HyzerKit
+
+@Suite("TokenClassifier")
+struct TokenClassifierTests {
+
+    let classifier = TokenClassifier()
+
+    // MARK: - Digit strings in range 1–10
+
+    @Test("digit string in range 1-10 returns number")
+    func test_classify_digitInRange_returnsNumber() {
+        // Given/When/Then
+        for n in 1...10 {
+            let result = classifier.classify(raw: "\(n)")
+            if case .number(let val) = result {
+                #expect(val == n)
+            } else {
+                Issue.record("Expected .number(\(n)) for '\(n)', got \(result)")
+            }
+        }
+    }
+
+    @Test("digit string zero returns noise")
+    func test_classify_digitZero_returnsNoise() {
+        // Given
+        let result = classifier.classify(raw: "0")
+        // Then
+        if case .noise = result { } else {
+            Issue.record("Expected .noise for 0, got \(result)")
+        }
+    }
+
+    @Test("digit string above 10 returns noise")
+    func test_classify_digitAboveTen_returnsNoise() {
+        // Given/When/Then
+        for n in [11, 15, 100] {
+            let result = classifier.classify(raw: "\(n)")
+            if case .noise = result { } else {
+                Issue.record("Expected .noise for \(n), got \(result)")
+            }
+        }
+    }
+
+    // MARK: - Word numbers
+
+    @Test("word numbers one through ten return correct number")
+    func test_classify_wordNumbers_returnNumber() {
+        // Given
+        let words: [(String, Int)] = [
+            ("one", 1), ("two", 2), ("three", 3), ("four", 4), ("five", 5),
+            ("six", 6), ("seven", 7), ("eight", 8), ("nine", 9), ("ten", 10)
+        ]
+
+        // When/Then
+        for (word, expected) in words {
+            let result = classifier.classify(raw: word)
+            if case .number(let val) = result {
+                #expect(val == expected, "Expected \(expected) for '\(word)'")
+            } else {
+                Issue.record("Expected .number(\(expected)) for '\(word)', got \(result)")
+            }
+        }
+    }
+
+    @Test("word number with uppercase is classified as number")
+    func test_classify_wordNumberUppercase_returnsNumber() {
+        // Given: classifier lowercases before lookup
+        let result = classifier.classify(raw: "Three")
+        // Then
+        if case .number(let val) = result {
+            #expect(val == 3)
+        } else {
+            Issue.record("Expected .number(3) for 'Three', got \(result)")
+        }
+    }
+
+    @Test("out-of-range word number returns noise")
+    func test_classify_wordNumberOutOfRange_returnsNoise() {
+        // Given: "thirty" is not in the valid number map
+        let result = classifier.classify(raw: "thirty")
+        // Then
+        if case .noise = result { } else {
+            Issue.record("Expected .noise for 'thirty', got \(result)")
+        }
+    }
+
+    // MARK: - Name tokens
+
+    @Test("alphabetic token returns name")
+    func test_classify_alphabeticToken_returnsName() {
+        // Given
+        let result = classifier.classify(raw: "Mike")
+        // Then
+        if case .name(let s) = result {
+            #expect(s == "Mike")
+        } else {
+            Issue.record("Expected .name(Mike), got \(result)")
+        }
+    }
+
+    @Test("token with punctuation returns name after trimming")
+    func test_classify_tokenWithTrailingPunctuation_returnsNameTrimmed() {
+        // Given: speech recognizer sometimes appends punctuation
+        let result = classifier.classify(raw: "Jake,")
+        // Then
+        if case .name(let s) = result {
+            #expect(s == "Jake")
+        } else {
+            Issue.record("Expected .name(Jake) for 'Jake,', got \(result)")
+        }
+    }
+
+    // MARK: - Noise tokens
+
+    @Test("alphanumeric mixed token returns noise")
+    func test_classify_mixedAlphanumeric_returnsNoise() {
+        // Given
+        let result = classifier.classify(raw: "4a")
+        // Then
+        if case .noise = result { } else {
+            Issue.record("Expected .noise for '4a', got \(result)")
+        }
+    }
+
+    @Test("empty string returns noise")
+    func test_classify_emptyString_returnsNoise() {
+        // Given
+        let result = classifier.classify(raw: "")
+        // Then
+        if case .noise = result { } else {
+            Issue.record("Expected .noise for empty string, got \(result)")
+        }
+    }
+}

--- a/HyzerKit/Tests/HyzerKitTests/Voice/VoiceParserTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/Voice/VoiceParserTests.swift
@@ -1,0 +1,174 @@
+import Testing
+import Foundation
+@testable import HyzerKit
+
+@Suite("VoiceParser")
+struct VoiceParserTests {
+
+    let parser = VoiceParser()
+
+    // Standard three-player roster used across tests
+    let players: [VoicePlayerEntry] = [
+        VoicePlayerEntry(playerID: "p1", displayName: "Michael", aliases: ["Mike"]),
+        VoicePlayerEntry(playerID: "p2", displayName: "Jake", aliases: []),
+        VoicePlayerEntry(playerID: "p3", displayName: "Sarah", aliases: [])
+    ]
+
+    // MARK: - AC2: Full transcript tokenize-classify-assemble
+
+    @Test("three-player transcript returns success with all scores")
+    func test_parse_threePlayerTranscript_returnsSuccess() {
+        // Given
+        let transcript = "Mike 3, Jake 4, Sarah 2"
+
+        // When
+        let result = parser.parse(transcript: transcript, players: players)
+
+        // Then
+        if case .success(let candidates) = result {
+            #expect(candidates.count == 3)
+            let byID = Dictionary(uniqueKeysWithValues: candidates.map { ($0.playerID, $0) })
+            #expect(byID["p1"]?.strokeCount == 3)
+            #expect(byID["p2"]?.strokeCount == 4)
+            #expect(byID["p3"]?.strokeCount == 2)
+        } else {
+            Issue.record("Expected .success, got \(result)")
+        }
+    }
+
+    // MARK: - AC4: Subset scoring valid
+
+    @Test("single-player subset transcript returns success")
+    func test_parse_subsetOnePlayer_returnsSuccess() {
+        // Given: only Jake scored
+        let transcript = "Jake 4"
+
+        // When
+        let result = parser.parse(transcript: transcript, players: players)
+
+        // Then: subset scoring is valid
+        if case .success(let candidates) = result {
+            #expect(candidates.count == 1)
+            #expect(candidates[0].playerID == "p2")
+            #expect(candidates[0].strokeCount == 4)
+        } else {
+            Issue.record("Expected .success for subset scoring Jake 4, got \(result)")
+        }
+    }
+
+    // MARK: - AC2: Partial result when some names unresolved
+
+    @Test("unresolvable name returns partial with recognized and unresolved")
+    func test_parse_unknownName_returnsPartial() {
+        // Given: "Zork" is not a known player
+        let transcript = "Jake 3, Zork 5"
+
+        // When
+        let result = parser.parse(transcript: transcript, players: players)
+
+        // Then
+        if case .partial(let recognized, let unresolved) = result {
+            #expect(recognized.count == 1)
+            #expect(recognized[0].playerID == "p2")
+            #expect(unresolved.contains("Zork"))
+        } else {
+            Issue.record("Expected .partial for unknown name Zork, got \(result)")
+        }
+    }
+
+    // MARK: - AC2: Failed result when no names resolved
+
+    @Test("no recognizable content returns failed")
+    func test_parse_noRecognizableContent_returnsFailed() {
+        // Given
+        let transcript = "blah blah blah"
+
+        // When
+        let result = parser.parse(transcript: transcript, players: players)
+
+        // Then
+        if case .failed(let t) = result {
+            #expect(t == transcript)
+        } else {
+            Issue.record("Expected .failed for unrecognizable transcript, got \(result)")
+        }
+    }
+
+    @Test("empty transcript returns failed")
+    func test_parse_emptyTranscript_returnsFailed() {
+        // Given
+        let result = parser.parse(transcript: "", players: players)
+        // Then
+        if case .failed = result { } else {
+            Issue.record("Expected .failed for empty transcript, got \(result)")
+        }
+    }
+
+    // MARK: - AC3: Alias matching
+
+    @Test("alias in transcript matches correct player")
+    func test_parse_alias_matchesCorrectPlayer() {
+        // Given: "Mike" is an alias for Michael (p1)
+        let transcript = "Mike 3"
+
+        // When
+        let result = parser.parse(transcript: transcript, players: players)
+
+        // Then
+        if case .success(let candidates) = result {
+            #expect(candidates[0].playerID == "p1")
+            #expect(candidates[0].displayName == "Michael")
+            #expect(candidates[0].strokeCount == 3)
+        } else {
+            Issue.record("Expected .success with Michael matched via Mike alias, got \(result)")
+        }
+    }
+
+    // MARK: - Word numbers
+
+    @Test("word number in transcript is parsed correctly")
+    func test_parse_wordNumber_parsedCorrectly() {
+        // Given
+        let transcript = "Jake three"
+
+        // When
+        let result = parser.parse(transcript: transcript, players: players)
+
+        // Then
+        if case .success(let candidates) = result {
+            #expect(candidates[0].strokeCount == 3)
+        } else {
+            Issue.record("Expected .success with strokeCount=3 for 'three', got \(result)")
+        }
+    }
+
+    // MARK: - Name without following number is skipped
+
+    @Test("name with no following number is skipped, paired name succeeds")
+    func test_parse_nameWithNoNumber_skipped() {
+        // Given: Mike has no number, Jake does
+        let transcript = "Mike Jake 4"
+
+        // When
+        let result = parser.parse(transcript: transcript, players: players)
+
+        // Then: Mike is dropped, Jake 4 succeeds
+        if case .success(let candidates) = result {
+            #expect(candidates.count == 1)
+            #expect(candidates[0].playerID == "p2")
+            #expect(candidates[0].strokeCount == 4)
+        } else {
+            Issue.record("Expected .success with only Jake 4, got \(result)")
+        }
+    }
+
+    // MARK: - AC6: VoiceParseResult conforms to Sendable
+
+    @Test("VoiceParseResult is Sendable")
+    func test_voiceParseResult_isSendable() {
+        // Given: Compile-time check that VoiceParseResult conforms to Sendable
+        let result: any Sendable = VoiceParseResult.success([])
+        // Then: assignment compiles → Sendable conformance verified
+        _ = result
+    }
+}

--- a/_bmad-output/implementation-artifacts/5-1-voice-recognition-and-parser-pipeline.md
+++ b/_bmad-output/implementation-artifacts/5-1-voice-recognition-and-parser-pipeline.md
@@ -238,8 +238,15 @@ claude-sonnet-4-6
 - `FuzzyNameMatcher` uses 4-tier matching: alias → display name exact → unique prefix → Levenshtein.
 - `TokenClassifier` uses a broad word-number map (one–hundred) with 1–10 range gate to correctly classify out-of-range words as `.noise` rather than `.name`.
 - `VoiceParser` assembly step correctly handles name-with-no-number (skips silently) and subset scoring.
-- 165 HyzerKit tests pass (0 regressions). iOS build succeeds with iPhone 17 simulator.
+- 166 HyzerKit tests pass (0 regressions). iOS build succeeds with iPhone 17 simulator.
 - `project.yml` updated with `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription`; `xcodegen generate` run and committed.
+
+### Code Review Fixes (claude-opus-4-6)
+
+- **H1**: `VoiceRecognitionService.recognize()` — added `hasResumed` guard to prevent `withCheckedThrowingContinuation` double-resume crash from `SFSpeechRecognitionTask` callback re-entry after `cancel()`.
+- **H2**: `VoiceRecognitionService.requestPermissions()` — speech recognition denial now throws `.recognitionUnavailable` instead of `.microphonePermissionDenied`.
+- **H3**: `VoiceRecognitionService.recognize()` — changed `[weak self]` to `[self]` in recognition callback to prevent async hang from unresumed continuation when service is deallocated during recording.
+- **M1**: Added `test_match_mediumSimilarity_returnsAmbiguous` to `FuzzyNameMatcherTests` — verifies Levenshtein 50-80% similarity returns `.ambiguous` (AC3 coverage gap).
 
 ### File List
 

--- a/_bmad-output/implementation-artifacts/5-1-voice-recognition-and-parser-pipeline.md
+++ b/_bmad-output/implementation-artifacts/5-1-voice-recognition-and-parser-pipeline.md
@@ -1,6 +1,6 @@
 # Story 5.1: Voice Recognition & Parser Pipeline
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -24,46 +24,46 @@ so that I can enter scores without touching the screen.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create `VoiceParseResult` enum and supporting types (AC: 6)
-  - [ ] 1.1: Create `HyzerKit/Sources/HyzerKit/Voice/VoiceParseResult.swift` — `Sendable` enum with `.success([ScoreCandidate])`, `.partial(recognized:unresolved:)`, `.failed(transcript:)`
-  - [ ] 1.2: Create `ScoreCandidate` struct (playerID: String, displayName: String, strokeCount: Int) — `Sendable`
-  - [ ] 1.3: Create `Token` enum/struct for classified tokens (name, number, noise) — `Sendable`
+- [x] Task 1: Create `VoiceParseResult` enum and supporting types (AC: 6)
+  - [x] 1.1: Create `HyzerKit/Sources/HyzerKit/Voice/VoiceParseResult.swift` — `Sendable` enum with `.success([ScoreCandidate])`, `.partial(recognized:unresolved:)`, `.failed(transcript:)`
+  - [x] 1.2: Create `ScoreCandidate` struct (playerID: String, displayName: String, strokeCount: Int) — `Sendable`
+  - [x] 1.3: Create `Token` enum/struct for classified tokens (name, number, noise) — `Sendable`
 
-- [ ] Task 2: Create `FuzzyNameMatcher` (AC: 3)
-  - [ ] 2.1: Create `HyzerKit/Sources/HyzerKit/Voice/FuzzyNameMatcher.swift` — `nonisolated`, `Sendable` struct
-  - [ ] 2.2: Implement alias map lookup: check `Player.aliases` array for exact case-insensitive match first
-  - [ ] 2.3: Implement Levenshtein distance fallback: accept >80% match, flag 50-80% as ambiguous, reject <50%
-  - [ ] 2.4: Initializer takes `[(playerID: String, displayName: String, aliases: [String])]` — no SwiftData dependency
-  - [ ] 2.5: Write `FuzzyNameMatcherTests.swift` in `HyzerKit/Tests/HyzerKitTests/Voice/`
+- [x] Task 2: Create `FuzzyNameMatcher` (AC: 3)
+  - [x] 2.1: Create `HyzerKit/Sources/HyzerKit/Voice/FuzzyNameMatcher.swift` — `nonisolated`, `Sendable` struct
+  - [x] 2.2: Implement alias map lookup: check `Player.aliases` array for exact case-insensitive match first
+  - [x] 2.3: Implement Levenshtein distance fallback: accept >80% match, flag 50-80% as ambiguous, reject <50%
+  - [x] 2.4: Initializer takes `[(playerID: String, displayName: String, aliases: [String])]` — no SwiftData dependency
+  - [x] 2.5: Write `FuzzyNameMatcherTests.swift` in `HyzerKit/Tests/HyzerKitTests/Voice/`
 
-- [ ] Task 3: Create `TokenClassifier` (AC: 2)
-  - [ ] 3.1: Create `HyzerKit/Sources/HyzerKit/Voice/TokenClassifier.swift` — `nonisolated`, `Sendable` struct
-  - [ ] 3.2: Classify tokens as `.name(String)`, `.number(Int)`, or `.noise(String)`
-  - [ ] 3.3: Handle both digit strings ("3") and word numbers ("three") — reject out-of-range (>10)
-  - [ ] 3.4: Write `TokenClassifierTests.swift` in `HyzerKit/Tests/HyzerKitTests/Voice/`
+- [x] Task 3: Create `TokenClassifier` (AC: 2)
+  - [x] 3.1: Create `HyzerKit/Sources/HyzerKit/Voice/TokenClassifier.swift` — `nonisolated`, `Sendable` struct
+  - [x] 3.2: Classify tokens as `.name(String)`, `.number(Int)`, or `.noise(String)`
+  - [x] 3.3: Handle both digit strings ("3") and word numbers ("three") — reject out-of-range (>10)
+  - [x] 3.4: Write `TokenClassifierTests.swift` in `HyzerKit/Tests/HyzerKitTests/Voice/`
 
-- [ ] Task 4: Create `VoiceParser` with tokenize-classify-assemble pipeline (AC: 2, 4)
-  - [ ] 4.1: Create `HyzerKit/Sources/HyzerKit/Voice/VoiceParser.swift` — `nonisolated`, `Sendable` struct
-  - [ ] 4.2: `parse(transcript:players:)` — tokenize transcript by whitespace/commas, classify each token, assemble name-number pairs
-  - [ ] 4.3: Return `.success` when all names resolved, `.partial` when some unresolved, `.failed` when none resolved
-  - [ ] 4.4: Handle subset scoring — "Jake 4" alone is valid (only scores Jake)
-  - [ ] 4.5: Write `VoiceParserTests.swift` in `HyzerKit/Tests/HyzerKitTests/Voice/`
+- [x] Task 4: Create `VoiceParser` with tokenize-classify-assemble pipeline (AC: 2, 4)
+  - [x] 4.1: Create `HyzerKit/Sources/HyzerKit/Voice/VoiceParser.swift` — `nonisolated`, `Sendable` struct
+  - [x] 4.2: `parse(transcript:players:)` — tokenize transcript by whitespace/commas, classify each token, assemble name-number pairs
+  - [x] 4.3: Return `.success` when all names resolved, `.partial` when some unresolved, `.failed` when none resolved
+  - [x] 4.4: Handle subset scoring — "Jake 4" alone is valid (only scores Jake)
+  - [x] 4.5: Write `VoiceParserTests.swift` in `HyzerKit/Tests/HyzerKitTests/Voice/`
 
-- [ ] Task 5: Create `VoiceRecognitionService` iOS-only wrapper (AC: 1, 5)
-  - [ ] 5.1: Create `HyzerApp/Services/VoiceRecognitionService.swift` — `@MainActor` class, imports `Speech` framework
-  - [ ] 5.2: Request microphone + speech recognition permissions (throw `VoiceParseError` on denial)
-  - [ ] 5.3: Configure `SFSpeechRecognizer` with `requiresOnDeviceRecognition = true`
-  - [ ] 5.4: `recognize()` async method returns transcript `String` (or throws `VoiceParseError`)
-  - [ ] 5.5: Add `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription` to `project.yml` under HyzerApp target
+- [x] Task 5: Create `VoiceRecognitionService` iOS-only wrapper (AC: 1, 5)
+  - [x] 5.1: Create `HyzerApp/Services/VoiceRecognitionService.swift` — `@MainActor` class, imports `Speech` framework
+  - [x] 5.2: Request microphone + speech recognition permissions (throw `VoiceParseError` on denial)
+  - [x] 5.3: Configure `SFSpeechRecognizer` with `requiresOnDeviceRecognition = true`
+  - [x] 5.4: `recognize()` async method returns transcript `String` (or throws `VoiceParseError`)
+  - [x] 5.5: Add `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription` to `project.yml` under HyzerApp target
 
-- [ ] Task 6: Create `VoiceParseError` enum (AC: 5)
-  - [ ] 6.1: Create in `HyzerKit/Sources/HyzerKit/Voice/VoiceParseError.swift` — `Error`, `Sendable`
-  - [ ] 6.2: Cases: `.microphonePermissionDenied`, `.recognitionUnavailable`, `.noSpeechDetected`
+- [x] Task 6: Create `VoiceParseError` enum (AC: 5)
+  - [x] 6.1: Create in `HyzerKit/Sources/HyzerKit/Voice/VoiceParseError.swift` — `Error`, `Sendable`
+  - [x] 6.2: Cases: `.microphonePermissionDenied`, `.recognitionUnavailable`, `.noSpeechDetected`
 
-- [ ] Task 7: Integration test — voice-to-standings pipeline (AC: 2, 4)
-  - [ ] 7.1: Create `HyzerKit/Tests/HyzerKitTests/Integration/VoiceToStandingsIntegrationTests.swift`
-  - [ ] 7.2: Feed transcript string into `VoiceParser.parse()`, assert `VoiceParseResult`, create `ScoreEvent`s via `ScoringService`, call `StandingsEngine.recompute()`, assert correct standings
-  - [ ] 7.3: No `SFSpeechRecognizer` needed — tests the parser-to-standings pipeline only
+- [x] Task 7: Integration test — voice-to-standings pipeline (AC: 2, 4)
+  - [x] 7.1: Create `HyzerKit/Tests/HyzerKitTests/Integration/VoiceToStandingsIntegrationTests.swift`
+  - [x] 7.2: Feed transcript string into `VoiceParser.parse()`, assert `VoiceParseResult`, create `ScoreEvent`s via `ScoringService`, call `StandingsEngine.recompute()`, assert correct standings
+  - [x] 7.3: No `SFSpeechRecognizer` needed — tests the parser-to-standings pipeline only
 
 ## Dev Notes
 
@@ -225,8 +225,33 @@ NSSpeechRecognitionUsageDescription: "HyzerApp uses speech recognition to conver
 
 ### Agent Model Used
 
+claude-sonnet-4-6
+
 ### Debug Log References
+
+- TokenClassifier word-number range check: initial implementation omitted range guard for word numbers (e.g. "thirty"). Fixed by broadening wordToNumber map to include out-of-range values (11–100) and applying `(1...10).contains(int)` guard to both digit and word paths.
 
 ### Completion Notes List
 
+- All HyzerKit voice types are `nonisolated`, `Sendable`, and import-free (no `Speech` framework).
+- `VoiceRecognitionService` lives exclusively in `HyzerApp/Services/` per platform isolation constraint.
+- `FuzzyNameMatcher` uses 4-tier matching: alias → display name exact → unique prefix → Levenshtein.
+- `TokenClassifier` uses a broad word-number map (one–hundred) with 1–10 range gate to correctly classify out-of-range words as `.noise` rather than `.name`.
+- `VoiceParser` assembly step correctly handles name-with-no-number (skips silently) and subset scoring.
+- 165 HyzerKit tests pass (0 regressions). iOS build succeeds with iPhone 17 simulator.
+- `project.yml` updated with `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription`; `xcodegen generate` run and committed.
+
 ### File List
+
+- HyzerKit/Sources/HyzerKit/Voice/VoiceParseResult.swift (new)
+- HyzerKit/Sources/HyzerKit/Voice/VoiceParseError.swift (new)
+- HyzerKit/Sources/HyzerKit/Voice/FuzzyNameMatcher.swift (new)
+- HyzerKit/Sources/HyzerKit/Voice/TokenClassifier.swift (new)
+- HyzerKit/Sources/HyzerKit/Voice/VoiceParser.swift (new)
+- HyzerKit/Tests/HyzerKitTests/Voice/FuzzyNameMatcherTests.swift (new)
+- HyzerKit/Tests/HyzerKitTests/Voice/TokenClassifierTests.swift (new)
+- HyzerKit/Tests/HyzerKitTests/Voice/VoiceParserTests.swift (new)
+- HyzerKit/Tests/HyzerKitTests/Integration/VoiceToStandingsIntegrationTests.swift (new)
+- HyzerApp/Services/VoiceRecognitionService.swift (new)
+- project.yml (modified — added NSMicrophoneUsageDescription, NSSpeechRecognitionUsageDescription)
+- HyzerApp/App/Info.plist (modified — generated by xcodegen)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -60,7 +60,7 @@ stories:
     epic: 4
   "5.1":
     title: "Voice Recognition & Parser Pipeline"
-    status: in-progress
+    status: review
     epic: 5
   "5.2":
     title: "Voice Confirmation Overlay & Auto-Commit"

--- a/project.yml
+++ b/project.yml
@@ -42,6 +42,8 @@ targets:
         UILaunchScreen: {}
         UIBackgroundModes:
           - remote-notification
+        NSMicrophoneUsageDescription: "HyzerApp uses the microphone to hear player names and scores for hands-free scoring."
+        NSSpeechRecognitionUsageDescription: "HyzerApp uses speech recognition to convert spoken scores into game entries. All processing happens on-device."
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.shotcowboystyle.hyzerapp


### PR DESCRIPTION
Closes #15

## User Story
As a user, I want to speak player names and scores and have the system understand them, so that I can enter scores without touching the screen.

## Changes
```
 HyzerApp.xcodeproj/project.pbxproj                 |   4 +
 HyzerApp/App/Info.plist                            |   4 +
 HyzerApp/Services/VoiceRecognitionService.swift    | 109 ++++++++++++
 HyzerKit/Sources/HyzerKit/Voice/FuzzyNameMatcher.swift  | 107 ++++++++++++
 HyzerKit/Sources/HyzerKit/Voice/TokenClassifier.swift   |  48 ++++++
 HyzerKit/Sources/HyzerKit/Voice/VoiceParseError.swift   |  11 ++
 HyzerKit/Sources/HyzerKit/Voice/VoiceParseResult.swift  |  34 ++++
 HyzerKit/Sources/HyzerKit/Voice/VoiceParser.swift  | 105 ++++++++++++
 HyzerKitTests/Integration/VoiceToStandingsIntegrationTests.swift | 187 ++++++++++++++
 HyzerKitTests/Voice/FuzzyNameMatcherTests.swift    | 176 ++++++++++++++++
 HyzerKitTests/Voice/TokenClassifierTests.swift     | 136 ++++++++++++
 HyzerKitTests/Voice/VoiceParserTests.swift         | 174 ++++++++++++++++
 15 files changed, 1171 insertions(+), 42 deletions(-)
```

- **VoiceParseResult** enum + **ScoreCandidate** + **Token** types — all `Sendable`, live in HyzerKit/Voice/
- **VoiceParseError** enum — `microphonePermissionDenied`, `recognitionUnavailable`, `noSpeechDetected`
- **FuzzyNameMatcher** — 4-tier matching: alias exact → display name exact → unique prefix → Levenshtein (≥80% accept, 50–80% ambiguous, <50% unmatched). Stateless `nonisolated` struct.
- **TokenClassifier** — classifies digit strings + word numbers (one–ten) with out-of-range rejection; purely alphabetic tokens → `.name`. Stateless `nonisolated` struct.
- **VoiceParser** — tokenize→classify→assemble pipeline. `parse(transcript:players:)` returns `.success`, `.partial`, or `.failed`. Subset scoring supported. No platform imports. Stateless `nonisolated` struct.
- **VoiceRecognitionService** — `@MainActor` iOS-only wrapper around `SFSpeechRecognizer` with `requiresOnDeviceRecognition = true`. Lives in HyzerApp/Services/ only (Speech framework not available on watchOS/macOS).
- **project.yml** — added `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription` Info.plist keys.

## Test Coverage
- `FuzzyNameMatcherTests` — alias match, display name match, unique prefix, ambiguous prefix, Levenshtein high/medium/low similarity, empty player list
- `TokenClassifierTests` — digit range 1–10, zero/out-of-range noise, word numbers one–ten, out-of-range word numbers (thirty), alphabetic names, empty string
- `VoiceParserTests` — three-player transcript, subset scoring, partial result, failed result, alias matching, word numbers, name-with-no-number skipping, Sendable conformance
- `VoiceToStandingsIntegrationTests` — full pipeline: transcript → VoiceParser → ScoringService → StandingsEngine → standings assertions (no SFSpeechRecognizer)
- 166 total HyzerKit tests pass. iOS build succeeds.

---
_Developed via BMAD workflow_