### PR TITLE
Story 5.2: Voice Confirmation Overlay & Auto-Commit

### DIFF
--- a/HyzerApp.xcodeproj/project.pbxproj
+++ b/HyzerApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		079960697F1DB732A0FE5870 /* ScorecardContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4619B6CC10DE1F2616549B7E /* ScorecardContainerView.swift */; };
 		0F9A0D4BCB7C9197C852E4D5 /* CourseEditorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A20DA3AF53A4644D429F /* CourseEditorViewModelTests.swift */; };
 		142C71682F24A3434B25C712 /* VoiceRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 751B4A4FAE27078A43BE3A3F /* VoiceRecognitionService.swift */; };
+		145858141B65FCC7F119CC25 /* VoiceOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FF87A290BB288FC3BDBD05 /* VoiceOverlayView.swift */; };
 		1B216ACD7E371E7C974AA480 /* RoundSetupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B4334F9A1744E9A0EA28B0 /* RoundSetupViewModelTests.swift */; };
 		1FD1D4A3ADFD21C470D1189F /* LeaderboardPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E77E4E336452EAE570A4531 /* LeaderboardPillView.swift */; };
 		264848715C0438CE283A1429 /* ScorecardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0271AF96B676CB2280840B30 /* ScorecardViewModel.swift */; };
@@ -23,12 +24,14 @@
 		5827D9E4DC7FC42B10CF812A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6A5193A54F5E0E9F5E5BA893 /* Assets.xcassets */; };
 		58FA343D3CDA32A3BBEDB9C0 /* LeaderboardExpandedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C43F8D9BA1A412FA48DB61 /* LeaderboardExpandedView.swift */; };
 		596A35E4701C525655211716 /* CourseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89EC7DCB75B63B758D964D2B /* CourseDetailView.swift */; };
+		5D8E4A77A4DDD95955B5F8D7 /* VoiceOverlayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0179A787B752A224A7B38E /* VoiceOverlayViewModel.swift */; };
 		602AE7FE552BCAAB9A145495 /* HyzerKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6AEC89D27BF2CC224C8D55BB /* HyzerKit */; };
 		64457CFB0B3C54CCACB441C1 /* SyncIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D25A260E0DBDD3FFD58E9A3 /* SyncIndicatorView.swift */; };
 		689356B498827861015A14A4 /* LiveNetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EAF2CE8A78AA9A463585BB /* LiveNetworkMonitor.swift */; };
 		6D665492C05385E1FB50E3B0 /* ScoreInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7876535734787458D7B0129 /* ScoreInputView.swift */; };
 		70D0955366D0881623788723 /* WatchRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65E7DE08C3408533CBAE374 /* WatchRootView.swift */; };
 		7291F41C97A3E4697FEBB72B /* ICloudIdentityResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD8964B40A6E0FDB412508C /* ICloudIdentityResolutionTests.swift */; };
+		7786FCF97AD45E381EA39B83 /* MockVoiceRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98688BE6063C2F5A47B1BEF /* MockVoiceRecognitionService.swift */; };
 		7823F1D6F90939B940EFAD1F /* LiveCloudKitClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BEC27ED6A658066DE3B9F9 /* LiveCloudKitClient.swift */; };
 		806B440616278187DD30A471 /* ScorecardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB32460AB85326B67BFFE3 /* ScorecardViewModelTests.swift */; };
 		824CB3E7C4FE4793E135E5B0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800D115E8B8669538227512F /* ContentView.swift */; };
@@ -41,7 +44,9 @@
 		A96BC87130D06BB117DA9903 /* OnboardingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A189F4C0A73BA714FD8BE50 /* OnboardingViewModelTests.swift */; };
 		AB7ECE958B351A749ED816BB /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EF3E5C7FF81BCA34D9DC08 /* OnboardingViewModel.swift */; };
 		AD08F59D9CCE35206B44FA22 /* HoleCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA34634C0B7110CFCB8DDC4 /* HoleCardView.swift */; };
+		BD0CC4EF29D368850F3C554C /* VoiceRecognitionServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB3171CF658AC6851293F50 /* VoiceRecognitionServiceProtocol.swift */; };
 		BED316BD11BE024B8F9B7B12 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4814FA35A94A0628886B8CF5 /* Assets.xcassets */; };
+		C7D6A40505B804067EE9CF36 /* VoiceOverlayViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D734EB6FDE18208A20EBAE /* VoiceOverlayViewModelTests.swift */; };
 		C8F759F08AE6456B030CC540 /* LeaderboardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AD8B9ED1E7E1DB41E7E024 /* LeaderboardViewModelTests.swift */; };
 		D09FF1B7C7769F36982ED120 /* CourseEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253755A91DD162D3BE8524C6 /* CourseEditorViewModel.swift */; };
 		D2EF055D37B19C14B5DEF295 /* HyzerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC2A9F18AFB9B84DAD30F16 /* HyzerApp.swift */; };
@@ -84,12 +89,14 @@
 /* Begin PBXFileReference section */
 		0271AF96B676CB2280840B30 /* ScorecardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScorecardViewModel.swift; sourceTree = "<group>"; };
 		07943A8909080D9EEB547B64 /* HyzerKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = HyzerKit; path = HyzerKit; sourceTree = SOURCE_ROOT; };
+		0CB3171CF658AC6851293F50 /* VoiceRecognitionServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecognitionServiceProtocol.swift; sourceTree = "<group>"; };
 		0F654A8DF69B0F48A4399DA2 /* RoundSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundSetupViewModel.swift; sourceTree = "<group>"; };
 		1AFA4C5EA37270895D500678 /* HyzerWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HyzerWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1C7BA35CCB400F30E2359CFE /* HyzerAppTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HyzerAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		253755A91DD162D3BE8524C6 /* CourseEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseEditorViewModel.swift; sourceTree = "<group>"; };
 		2AD8964B40A6E0FDB412508C /* ICloudIdentityResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudIdentityResolutionTests.swift; sourceTree = "<group>"; };
 		2CC2A9F18AFB9B84DAD30F16 /* HyzerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyzerApp.swift; sourceTree = "<group>"; };
+		39D734EB6FDE18208A20EBAE /* VoiceOverlayViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverlayViewModelTests.swift; sourceTree = "<group>"; };
 		39EF3E5C7FF81BCA34D9DC08 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		3D25A260E0DBDD3FFD58E9A3 /* SyncIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncIndicatorView.swift; sourceTree = "<group>"; };
 		41F4A3FDA72AE73321E44E1B /* LiveICloudIdentityProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveICloudIdentityProvider.swift; sourceTree = "<group>"; };
@@ -97,6 +104,7 @@
 		46C43F8D9BA1A412FA48DB61 /* LeaderboardExpandedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardExpandedView.swift; sourceTree = "<group>"; };
 		4814FA35A94A0628886B8CF5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		54DB32460AB85326B67BFFE3 /* ScorecardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScorecardViewModelTests.swift; sourceTree = "<group>"; };
+		59FF87A290BB288FC3BDBD05 /* VoiceOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverlayView.swift; sourceTree = "<group>"; };
 		6A5193A54F5E0E9F5E5BA893 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6E77E4E336452EAE570A4531 /* LeaderboardPillView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardPillView.swift; sourceTree = "<group>"; };
 		751B4A4FAE27078A43BE3A3F /* VoiceRecognitionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecognitionService.swift; sourceTree = "<group>"; };
@@ -110,11 +118,13 @@
 		9A189F4C0A73BA714FD8BE50 /* OnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		A0348F5FC211306493C34EDC /* HyzerApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HyzerApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A11CB2EA23B021251B93ADEE /* LeaderboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardViewModel.swift; sourceTree = "<group>"; };
+		AA0179A787B752A224A7B38E /* VoiceOverlayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverlayViewModel.swift; sourceTree = "<group>"; };
 		B04BA312C596DB4B88277D5D /* RoundSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundSummaryViewModel.swift; sourceTree = "<group>"; };
 		B5B4334F9A1744E9A0EA28B0 /* RoundSetupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundSetupViewModelTests.swift; sourceTree = "<group>"; };
 		BC03976642023E145926871B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		BEA34634C0B7110CFCB8DDC4 /* HoleCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoleCardView.swift; sourceTree = "<group>"; };
 		C2DE096DC71267D6C2C700CD /* HyzerApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HyzerApp.entitlements; sourceTree = "<group>"; };
+		C98688BE6063C2F5A47B1BEF /* MockVoiceRecognitionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockVoiceRecognitionService.swift; sourceTree = "<group>"; };
 		CB2045C0AF8BAAD5936DEC19 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		D0EAF2CE8A78AA9A463585BB /* LiveNetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveNetworkMonitor.swift; sourceTree = "<group>"; };
 		D4DFB1F9AC07FE1B019DC349 /* AppServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServices.swift; sourceTree = "<group>"; };
@@ -165,6 +175,7 @@
 				0F654A8DF69B0F48A4399DA2 /* RoundSetupViewModel.swift */,
 				B04BA312C596DB4B88277D5D /* RoundSummaryViewModel.swift */,
 				0271AF96B676CB2280840B30 /* ScorecardViewModel.swift */,
+				AA0179A787B752A224A7B38E /* VoiceOverlayViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -235,6 +246,14 @@
 			path = Courses;
 			sourceTree = "<group>";
 		};
+		A328280BAEB8C4DC952A5113 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				C98688BE6063C2F5A47B1BEF /* MockVoiceRecognitionService.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		A3C6B5A93C04D6F5020F06AF /* Rounds */ = {
 			isa = PBXGroup;
 			children = (
@@ -246,6 +265,7 @@
 		A6513A9E2C4A140FCD7073D2 /* HyzerAppTests */ = {
 			isa = PBXGroup;
 			children = (
+				A328280BAEB8C4DC952A5113 /* Mocks */,
 				E1F2A20DA3AF53A4644D429F /* CourseEditorViewModelTests.swift */,
 				2AD8964B40A6E0FDB412508C /* ICloudIdentityResolutionTests.swift */,
 				95AD8B9ED1E7E1DB41E7E024 /* LeaderboardViewModelTests.swift */,
@@ -253,6 +273,7 @@
 				B5B4334F9A1744E9A0EA28B0 /* RoundSetupViewModelTests.swift */,
 				94FEC7DFA3A2314C63F5DD78 /* RoundSummaryViewModelTests.swift */,
 				54DB32460AB85326B67BFFE3 /* ScorecardViewModelTests.swift */,
+				39D734EB6FDE18208A20EBAE /* VoiceOverlayViewModelTests.swift */,
 			);
 			path = HyzerAppTests;
 			sourceTree = "<group>";
@@ -280,6 +301,7 @@
 			isa = PBXGroup;
 			children = (
 				AC5AC0A99416970B55C0E550 /* App */,
+				D2C60444F354546FCB3444E9 /* Protocols */,
 				E537675A7E8B329D16767E55 /* Resources */,
 				E0B19F0BA4504AD1BC89902F /* Services */,
 				2EA27EE230CA76ADDCD6A13A /* ViewModels */,
@@ -295,6 +317,7 @@
 				E63536A325A8FD3F5E743896 /* RoundSummaryView.swift */,
 				4619B6CC10DE1F2616549B7E /* ScorecardContainerView.swift */,
 				F7876535734787458D7B0129 /* ScoreInputView.swift */,
+				59FF87A290BB288FC3BDBD05 /* VoiceOverlayView.swift */,
 			);
 			path = Scoring;
 			sourceTree = "<group>";
@@ -327,6 +350,14 @@
 				8F4C479F6E70B8F442F6A454 /* Packages */,
 				EEE56E501DA65667981A9D89 /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		D2C60444F354546FCB3444E9 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				0CB3171CF658AC6851293F50 /* VoiceRecognitionServiceProtocol.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 		E0B19F0BA4504AD1BC89902F /* Services */ = {
@@ -507,10 +538,12 @@
 				0F9A0D4BCB7C9197C852E4D5 /* CourseEditorViewModelTests.swift in Sources */,
 				7291F41C97A3E4697FEBB72B /* ICloudIdentityResolutionTests.swift in Sources */,
 				C8F759F08AE6456B030CC540 /* LeaderboardViewModelTests.swift in Sources */,
+				7786FCF97AD45E381EA39B83 /* MockVoiceRecognitionService.swift in Sources */,
 				A96BC87130D06BB117DA9903 /* OnboardingViewModelTests.swift in Sources */,
 				1B216ACD7E371E7C974AA480 /* RoundSetupViewModelTests.swift in Sources */,
 				2D30EA8B327D17A6C16A3310 /* RoundSummaryViewModelTests.swift in Sources */,
 				806B440616278187DD30A471 /* ScorecardViewModelTests.swift in Sources */,
+				C7D6A40505B804067EE9CF36 /* VoiceOverlayViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -543,7 +576,10 @@
 				079960697F1DB732A0FE5870 /* ScorecardContainerView.swift in Sources */,
 				264848715C0438CE283A1429 /* ScorecardViewModel.swift in Sources */,
 				64457CFB0B3C54CCACB441C1 /* SyncIndicatorView.swift in Sources */,
+				145858141B65FCC7F119CC25 /* VoiceOverlayView.swift in Sources */,
+				5D8E4A77A4DDD95955B5F8D7 /* VoiceOverlayViewModel.swift in Sources */,
 				142C71682F24A3434B25C712 /* VoiceRecognitionService.swift in Sources */,
+				BD0CC4EF29D368850F3C554C /* VoiceRecognitionServiceProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HyzerApp/App/AppServices.swift
+++ b/HyzerApp/App/AppServices.swift
@@ -21,6 +21,7 @@ final class AppServices {
     let roundLifecycleManager: RoundLifecycleManager
     let syncEngine: SyncEngine
     let syncScheduler: SyncScheduler
+    let voiceRecognitionService: VoiceRecognitionService
     private(set) var iCloudRecordName: String?
 
     /// Observable sync state, bridged from the `SyncEngine` actor via an async stream.
@@ -52,6 +53,7 @@ final class AppServices {
         )
         let deviceID = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
         self.scoringService = ScoringService(modelContext: modelContainer.mainContext, deviceID: deviceID)
+        self.voiceRecognitionService = VoiceRecognitionService()
         self.iCloudIdentityProvider = iCloudIdentityProvider
     }
 

--- a/HyzerApp/Protocols/VoiceRecognitionServiceProtocol.swift
+++ b/HyzerApp/Protocols/VoiceRecognitionServiceProtocol.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Testability abstraction over `VoiceRecognitionService`.
+///
+/// Allows `VoiceOverlayViewModel` to be tested with a mock in place of the real
+/// `SFSpeechRecognizer`-backed implementation. Lives in `HyzerApp/Protocols/` because
+/// it references behavior specific to the iOS Speech framework — it does NOT go in HyzerKit.
+@MainActor
+protocol VoiceRecognitionServiceProtocol: AnyObject {
+    /// Records and transcribes speech.
+    ///
+    /// - Returns: The transcribed string from on-device recognition.
+    /// - Throws: `VoiceParseError` on permission denial, unavailability, or silence.
+    func recognize() async throws -> String
+
+    /// Stops the audio engine and cancels any active recognition task.
+    func stopListening()
+}

--- a/HyzerApp/Services/VoiceRecognitionService.swift
+++ b/HyzerApp/Services/VoiceRecognitionService.swift
@@ -9,7 +9,7 @@ import HyzerKit
 ///
 /// `@MainActor` — interacts with UI permission prompts and AVAudioEngine.
 @MainActor
-public final class VoiceRecognitionService {
+public final class VoiceRecognitionService: VoiceRecognitionServiceProtocol {
 
     private let speechRecognizer: SFSpeechRecognizer?
     private var recognitionTask: SFSpeechRecognitionTask?
@@ -80,6 +80,13 @@ public final class VoiceRecognitionService {
                 }
             }
         }
+    }
+
+    /// Stops the audio engine and cancels any active recognition task.
+    ///
+    /// Safe to call when no recognition is active — all operations are idempotent.
+    public func stopListening() {
+        stopAudioEngine()
     }
 
     private func stopAudioEngine() {

--- a/HyzerApp/ViewModels/VoiceOverlayViewModel.swift
+++ b/HyzerApp/ViewModels/VoiceOverlayViewModel.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Observation
+import HyzerKit
+
+/// Drives the voice confirmation overlay UX.
+///
+/// Lifecycle: `startListening()` → recognition → parsing → `.confirming` state →
+/// 1.5s auto-commit timer → `commitScores()` → `.committed`.
+///
+/// Injected into `ScorecardContainerView` when the user taps the mic button.
+/// Lives in `HyzerApp/` — depends on `VoiceRecognitionServiceProtocol` which
+/// references iOS Speech framework behaviour.
+@MainActor
+@Observable
+final class VoiceOverlayViewModel {
+
+    // MARK: - State
+
+    enum State {
+        case idle
+        case listening
+        case confirming([ScoreCandidate])
+        case committed
+        case dismissed
+        case error(VoiceParseError)
+    }
+
+    private(set) var state: State = .idle
+
+    /// `true` after `commitScores()` completes successfully. Equatable for SwiftUI `onChange`.
+    private(set) var isCommitted: Bool = false
+
+    /// `true` once the overlay reaches a terminal state (committed, dismissed, or error).
+    /// Equatable for SwiftUI `onChange` — use this to drive overlay dismissal.
+    private(set) var isTerminated: Bool = false
+
+    // MARK: - Dependencies
+
+    private let voiceRecognitionService: any VoiceRecognitionServiceProtocol
+    private let scoringService: ScoringService
+    private let parser: VoiceParser
+    private let roundID: UUID
+    private let holeNumber: Int
+    private let reportedByPlayerID: UUID
+    private let players: [VoicePlayerEntry]
+
+    // MARK: - Timer
+
+    private var timerTask: Task<Void, Never>?
+
+    /// When `true` (VoiceOver focus on overlay), the auto-commit timer is paused.
+    var isVoiceOverFocused: Bool = false {
+        didSet {
+            if isVoiceOverFocused {
+                timerTask?.cancel()
+                timerTask = nil
+            } else if case .confirming = state {
+                startAutoCommitTimer()
+            }
+        }
+    }
+
+    // MARK: - Init
+
+    init(
+        voiceRecognitionService: any VoiceRecognitionServiceProtocol,
+        scoringService: ScoringService,
+        parser: VoiceParser,
+        roundID: UUID,
+        holeNumber: Int,
+        reportedByPlayerID: UUID,
+        players: [VoicePlayerEntry]
+    ) {
+        self.voiceRecognitionService = voiceRecognitionService
+        self.scoringService = scoringService
+        self.parser = parser
+        self.roundID = roundID
+        self.holeNumber = holeNumber
+        self.reportedByPlayerID = reportedByPlayerID
+        self.players = players
+    }
+
+    // MARK: - Public Interface
+
+    /// Begins listening and parses the resulting transcript.
+    ///
+    /// On `.success`, transitions to `.confirming` and starts the auto-commit timer.
+    /// On `.partial`, only the resolved candidates are shown.
+    /// On `.failed` or thrown error, transitions to `.error`.
+    func startListening() {
+        state = .listening
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let transcript = try await voiceRecognitionService.recognize()
+                let result = parser.parse(transcript: transcript, players: players)
+                switch result {
+                case .success(let candidates):
+                    state = .confirming(candidates)
+                    if !isVoiceOverFocused {
+                        startAutoCommitTimer()
+                    }
+                case .partial(let recognized, _):
+                    // Story 5.3 will handle partial UX; for now, confirm what was recognised
+                    state = .confirming(recognized)
+                    if !isVoiceOverFocused {
+                        startAutoCommitTimer()
+                    }
+                case .failed:
+                    state = .error(.noSpeechDetected)
+                    isTerminated = true
+                }
+            } catch let error as VoiceParseError {
+                state = .error(error)
+                isTerminated = true
+            } catch {
+                state = .error(.recognitionUnavailable)
+                isTerminated = true
+            }
+        }
+    }
+
+    /// Updates a score candidate at `index` and resets the auto-commit timer to 1.5s.
+    func correctScore(at index: Int, newStrokeCount: Int) {
+        guard case .confirming(var candidates) = state else { return }
+        guard candidates.indices.contains(index) else { return }
+        candidates[index] = ScoreCandidate(
+            playerID: candidates[index].playerID,
+            displayName: candidates[index].displayName,
+            strokeCount: newStrokeCount
+        )
+        state = .confirming(candidates)
+        if !isVoiceOverFocused {
+            startAutoCommitTimer()
+        }
+    }
+
+    /// Commits all confirmed candidates as ScoreEvents via `ScoringService`.
+    func commitScores() {
+        timerTask?.cancel()
+        timerTask = nil
+        guard case .confirming(let candidates) = state else { return }
+        do {
+            for candidate in candidates {
+                try scoringService.createScoreEvent(
+                    roundID: roundID,
+                    holeNumber: holeNumber,
+                    playerID: candidate.playerID,
+                    strokeCount: candidate.strokeCount,
+                    reportedByPlayerID: reportedByPlayerID
+                )
+            }
+            state = .committed
+            isCommitted = true
+            isTerminated = true
+        } catch {
+            // Safe to surface as error: commit failure means no ScoreEvents were written for this candidate
+            state = .error(.recognitionUnavailable)
+            isTerminated = true
+        }
+    }
+
+    /// Cancels the overlay: stops listening, cancels the timer, and sets state to `.dismissed`.
+    func cancel() {
+        timerTask?.cancel()
+        timerTask = nil
+        voiceRecognitionService.stopListening()
+        state = .dismissed
+        isTerminated = true
+    }
+
+    // MARK: - Private
+
+    private func startAutoCommitTimer() {
+        timerTask?.cancel()
+        timerTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(1.5))
+            guard !Task.isCancelled else { return }
+            self?.commitScores()
+        }
+    }
+}

--- a/HyzerApp/Views/Scoring/VoiceOverlayView.swift
+++ b/HyzerApp/Views/Scoring/VoiceOverlayView.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+import HyzerKit
+
+/// Translucent overlay shown after voice recognition completes.
+///
+/// Displays parsed player-score pairs with a 1.5-second auto-commit progress indicator.
+/// Supports inline correction via an expanded score picker (same `ScoreInputView` pattern).
+/// Presented as a `.overlay()` on `ScorecardContainerView` — not a sheet or fullScreenCover.
+struct VoiceOverlayView: View {
+    @Bindable var viewModel: VoiceOverlayViewModel
+    let par: Int
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @AccessibilityFocusState private var overlayFocused: Bool
+
+    @State private var progress: Double = 0
+    @State private var progressAnimation: Animation? = nil
+    @State private var correctionIndex: Int? = nil
+
+    var body: some View {
+        Group {
+            switch viewModel.state {
+            case .listening:
+                listeningView
+            case .confirming(let candidates):
+                confirmingView(candidates: candidates)
+            default:
+                EmptyView()
+            }
+        }
+    }
+
+    // MARK: - Listening state
+
+    private var listeningView: some View {
+        VStack(spacing: SpacingTokens.md) {
+            Image(systemName: "waveform.circle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(Color.accentPrimary)
+                .symbolEffect(.pulse, options: .repeating)
+                .accessibilityHidden(true)
+            Text("Listening…")
+                .font(TypographyTokens.h3)
+                .foregroundStyle(Color.textPrimary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(SpacingTokens.lg)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .padding(.horizontal, SpacingTokens.md)
+    }
+
+    // MARK: - Confirming state
+
+    private func confirmingView(candidates: [ScoreCandidate]) -> some View {
+        VStack(alignment: .leading, spacing: SpacingTokens.sm) {
+            Text("Scores heard")
+                .font(TypographyTokens.caption)
+                .foregroundStyle(Color.textSecondary)
+                .padding(.horizontal, SpacingTokens.md)
+
+            ForEach(Array(candidates.enumerated()), id: \.offset) { index, candidate in
+                if correctionIndex == index {
+                    ScoreInputView(
+                        playerName: candidate.displayName,
+                        par: par,
+                        preSelectedScore: candidate.strokeCount,
+                        onSelect: { newScore in
+                            viewModel.correctScore(at: index, newStrokeCount: newScore)
+                            correctionIndex = nil
+                        },
+                        onCancel: { correctionIndex = nil }
+                    )
+                    .padding(.horizontal, SpacingTokens.sm)
+                } else {
+                    playerScoreRow(candidate: candidate, index: index, par: par)
+                }
+            }
+
+            progressBar
+
+            Text("Tap to correct")
+                .font(TypographyTokens.caption)
+                .foregroundStyle(Color.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .accessibilityHidden(true)
+
+            Button(action: { viewModel.commitScores() }) {
+                Text("Commit Scores")
+                    .font(TypographyTokens.caption)
+                    .foregroundStyle(Color.textSecondary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, SpacingTokens.xs)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Commit Scores")
+            .padding(.horizontal, SpacingTokens.md)
+        }
+        .padding(.vertical, SpacingTokens.md)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .padding(.horizontal, SpacingTokens.md)
+        .onAppear { startProgress() }
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
+        .accessibilityFocused($overlayFocused)
+        .onChange(of: overlayFocused) { _, focused in
+            viewModel.isVoiceOverFocused = focused
+        }
+    }
+
+    // MARK: - Player row
+
+    private func playerScoreRow(candidate: ScoreCandidate, index: Int, par: Int) -> some View {
+        Button(action: { correctionIndex = index }) {
+            HStack(alignment: .center, spacing: SpacingTokens.xs) {
+                Text(candidate.displayName)
+                    .font(TypographyTokens.h2)
+                    .foregroundStyle(Color.textPrimary)
+                    .lineLimit(1)
+
+                // Dotted leader
+                DottedLeader()
+                    .accessibilityHidden(true)
+
+                Text("\(candidate.strokeCount)")
+                    .font(TypographyTokens.scoreLarge)
+                    .foregroundStyle(scoreColor(strokes: candidate.strokeCount, par: par))
+                    .monospacedDigit()
+            }
+            .frame(minHeight: 56)
+            .padding(.horizontal, SpacingTokens.md)
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel(for: candidate, par: par))
+        .accessibilityHint("Double-tap to correct")
+    }
+
+    // MARK: - Progress bar
+
+    private var progressBar: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.backgroundTertiary)
+                    .frame(height: 4)
+                Capsule()
+                    .fill(Color.accentPrimary)
+                    .frame(width: geo.size.width * progress, height: 4)
+                    .animation(progressAnimation, value: progress)
+            }
+        }
+        .frame(height: 4)
+        .padding(.horizontal, SpacingTokens.md)
+        .accessibilityHidden(true)
+    }
+
+    // MARK: - Helpers
+
+    private func startProgress() {
+        progress = 0
+        if reduceMotion {
+            progress = 1
+        } else {
+            progressAnimation = .linear(duration: 1.5)
+            progress = 1
+        }
+    }
+
+    private func scoreColor(strokes: Int, par: Int) -> Color {
+        let delta = strokes - par
+        switch delta {
+        case ..<0:  return .scoreUnderPar
+        case 0:     return .scoreAtPar
+        case 1:     return .scoreOverPar
+        default:    return .scoreWayOver
+        }
+    }
+
+    private func accessibilityLabel(for candidate: ScoreCandidate, par: Int) -> String {
+        let delta = candidate.strokeCount - par
+        let parDescription: String
+        switch delta {
+        case ..<(-1): parDescription = "\(abs(delta)) under par"
+        case -1:      parDescription = "birdie"
+        case 0:       parDescription = "par"
+        case 1:       parDescription = "bogey"
+        default:      parDescription = "\(delta) over par"
+        }
+        return "\(candidate.displayName), \(candidate.strokeCount), \(parDescription)"
+    }
+}
+
+// MARK: - DottedLeader
+
+/// A horizontal dotted line used as a leader between player name and score.
+private struct DottedLeader: View {
+    var body: some View {
+        GeometryReader { geo in
+            Path { path in
+                let y = geo.size.height / 2
+                path.move(to: CGPoint(x: 0, y: y))
+                path.addLine(to: CGPoint(x: geo.size.width, y: y))
+            }
+            .stroke(
+                Color.textSecondary.opacity(0.5),
+                style: StrokeStyle(lineWidth: 1, dash: [3, 4])
+            )
+        }
+        .frame(height: 1)
+    }
+}

--- a/HyzerAppTests/ICloudIdentityResolutionTests.swift
+++ b/HyzerAppTests/ICloudIdentityResolutionTests.swift
@@ -1,7 +1,25 @@
 import Testing
 import SwiftData
+import CloudKit
 @testable import HyzerKit
 @testable import HyzerApp
+
+// MARK: - Test Stubs
+
+/// Minimal no-op stub for AppServices construction in iCloud identity tests.
+private struct StubCloudKitClient: CloudKitClient, @unchecked Sendable {
+    func save(_ records: [CKRecord]) async throws -> [CKRecord] { [] }
+    func fetch(matching query: CKQuery, in zone: CKRecordZone.ID?) async throws -> [CKRecord] { [] }
+    func subscribe(to recordType: CKRecord.RecordType, predicate: NSPredicate) async throws -> CKSubscription.ID { "" }
+    func deleteSubscription(_ subscriptionID: CKSubscription.ID) async throws {}
+    func fetchAllSubscriptionIDs() async throws -> [CKSubscription.ID] { [] }
+}
+
+/// Minimal no-op stub for AppServices construction in iCloud identity tests.
+private struct StubNetworkMonitor: NetworkMonitor {
+    var isConnected: Bool { true }
+    var pathUpdates: AsyncStream<Bool> { AsyncStream { _ in } }
+}
 
 // MARK: - Test Mock
 
@@ -33,7 +51,9 @@ struct ICloudIdentityResolutionTests {
         let container = try ModelContainer(for: Player.self, configurations: config)
         let services = AppServices(
             modelContainer: container,
-            iCloudIdentityProvider: provider
+            iCloudIdentityProvider: provider,
+            cloudKitClient: StubCloudKitClient(),
+            networkMonitor: StubNetworkMonitor()
         )
         let context = ModelContext(container)
         return (services, context)

--- a/HyzerAppTests/Mocks/MockVoiceRecognitionService.swift
+++ b/HyzerAppTests/Mocks/MockVoiceRecognitionService.swift
@@ -1,0 +1,25 @@
+import Foundation
+@testable import HyzerApp
+@testable import HyzerKit
+
+/// Test double for `VoiceRecognitionServiceProtocol`.
+///
+/// Configure `transcriptToReturn` for happy-path tests.
+/// Configure `errorToThrow` to exercise error handling in `VoiceOverlayViewModel`.
+@MainActor
+final class MockVoiceRecognitionService: VoiceRecognitionServiceProtocol {
+    var transcriptToReturn: String = ""
+    var errorToThrow: VoiceParseError?
+    var recognizeCallCount = 0
+    var stopListeningCallCount = 0
+
+    func recognize() async throws -> String {
+        recognizeCallCount += 1
+        if let error = errorToThrow { throw error }
+        return transcriptToReturn
+    }
+
+    func stopListening() {
+        stopListeningCallCount += 1
+    }
+}

--- a/HyzerAppTests/VoiceOverlayViewModelTests.swift
+++ b/HyzerAppTests/VoiceOverlayViewModelTests.swift
@@ -1,0 +1,242 @@
+import Testing
+import SwiftData
+import Foundation
+@testable import HyzerApp
+@testable import HyzerKit
+
+/// Tests for VoiceOverlayViewModel (Story 5.2).
+///
+/// Framework: Swift Testing (`@Suite`, `@Test`, `#expect`).
+/// All tests are `@MainActor` matching the ViewModel's isolation.
+@Suite("VoiceOverlayViewModel")
+@MainActor
+struct VoiceOverlayViewModelTests {
+
+    // MARK: - Helpers
+
+    private func makeContext() throws -> (ModelContainer, ModelContext) {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Player.self, Course.self, Hole.self, Round.self, ScoreEvent.self,
+            configurations: config
+        )
+        return (container, ModelContext(container))
+    }
+
+    private func makeVM(
+        mock: MockVoiceRecognitionService = MockVoiceRecognitionService(),
+        context: ModelContext,
+        players: [VoicePlayerEntry] = []
+    ) -> (VoiceOverlayViewModel, ScoringService) {
+        let service = ScoringService(modelContext: context, deviceID: "test-device")
+        let vm = VoiceOverlayViewModel(
+            voiceRecognitionService: mock,
+            scoringService: service,
+            parser: VoiceParser(),
+            roundID: UUID(),
+            holeNumber: 1,
+            reportedByPlayerID: UUID(),
+            players: players
+        )
+        return (vm, service)
+    }
+
+    private func samplePlayers() -> [VoicePlayerEntry] {
+        [
+            VoicePlayerEntry(playerID: "player-mike", displayName: "Mike", aliases: []),
+            VoicePlayerEntry(playerID: "player-jake", displayName: "Jake", aliases: []),
+            VoicePlayerEntry(playerID: "player-sarah", displayName: "Sarah", aliases: [])
+        ]
+    }
+
+    // MARK: - 6.3: startListening with successful transcript → .confirming with correct candidates
+
+    @Test("startListening_successfulTranscript_setsConfirmingWithCandidates")
+    func test_startListening_successfulTranscript_setsConfirmingWithCandidates() async throws {
+        // Given
+        let mock = MockVoiceRecognitionService()
+        mock.transcriptToReturn = "Mike 3 Jake 4"
+        let (_, context) = try makeContext()
+        let (vm, _) = makeVM(mock: mock, context: context, players: samplePlayers())
+
+        // When
+        vm.startListening()
+        // Allow async recognition to propagate
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Then
+        if case .confirming(let candidates) = vm.state {
+            #expect(candidates.count == 2)
+            #expect(candidates.first?.displayName == "Mike")
+            #expect(candidates.first?.strokeCount == 3)
+            #expect(candidates.last?.displayName == "Jake")
+            #expect(candidates.last?.strokeCount == 4)
+        } else {
+            Issue.record("Expected .confirming state, got \(vm.state)")
+        }
+    }
+
+    // MARK: - 6.4: commitScores creates one ScoreEvent per candidate
+
+    @Test("commitScores_createsOneScoreEventPerCandidate")
+    func test_commitScores_createsOneScoreEventPerCandidate() async throws {
+        // Given
+        let mock = MockVoiceRecognitionService()
+        mock.transcriptToReturn = "Mike 3 Jake 4"
+        let (_, context) = try makeContext()
+        let (vm, _) = makeVM(mock: mock, context: context, players: samplePlayers())
+
+        vm.startListening()
+        try await Task.sleep(for: .milliseconds(100))
+        guard case .confirming = vm.state else {
+            Issue.record("Setup: expected .confirming state")
+            return
+        }
+
+        // When
+        vm.commitScores()
+
+        // Then
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched.count == 2)
+        let strokes = Set(fetched.map(\.strokeCount))
+        #expect(strokes.contains(3))
+        #expect(strokes.contains(4))
+        if case .committed = vm.state { } else {
+            Issue.record("Expected .committed state, got \(vm.state)")
+        }
+        #expect(vm.isCommitted == true)
+        #expect(vm.isTerminated == true)
+    }
+
+    // MARK: - 6.5: correctScore updates candidate and resets timer
+
+    @Test("correctScore_updatesStrokeCount")
+    func test_correctScore_updatesStrokeCount() async throws {
+        // Given
+        let mock = MockVoiceRecognitionService()
+        mock.transcriptToReturn = "Mike 3"
+        let (_, context) = try makeContext()
+        let (vm, _) = makeVM(mock: mock, context: context, players: samplePlayers())
+
+        vm.startListening()
+        try await Task.sleep(for: .milliseconds(100))
+        guard case .confirming = vm.state else {
+            Issue.record("Setup: expected .confirming state")
+            return
+        }
+
+        // When
+        vm.correctScore(at: 0, newStrokeCount: 5)
+
+        // Then
+        if case .confirming(let candidates) = vm.state {
+            #expect(candidates[0].strokeCount == 5)
+        } else {
+            Issue.record("Expected .confirming state after correction")
+        }
+    }
+
+    // MARK: - 6.6: cancel → .dismissed, no ScoreEvents
+
+    @Test("cancel_setsDismissedState_createsNoScoreEvents")
+    func test_cancel_setsDismissedState_createsNoScoreEvents() async throws {
+        // Given
+        let mock = MockVoiceRecognitionService()
+        mock.transcriptToReturn = "Mike 3 Jake 4"
+        let (_, context) = try makeContext()
+        let (vm, _) = makeVM(mock: mock, context: context, players: samplePlayers())
+
+        vm.startListening()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // When
+        vm.cancel()
+
+        // Then
+        if case .dismissed = vm.state { } else {
+            Issue.record("Expected .dismissed state, got \(vm.state)")
+        }
+        #expect(vm.isTerminated == true)
+        #expect(vm.isCommitted == false)
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched.isEmpty)
+        #expect(mock.stopListeningCallCount == 1)
+    }
+
+    // MARK: - 6.7: subset scoring — single player transcript commits only that player's score
+
+    @Test("startListening_singlePlayerTranscript_commitsOnlyThatPlayer")
+    func test_startListening_singlePlayerTranscript_commitsOnlyThatPlayer() async throws {
+        // Given
+        let mock = MockVoiceRecognitionService()
+        mock.transcriptToReturn = "Jake 4"
+        let (_, context) = try makeContext()
+        let (vm, _) = makeVM(mock: mock, context: context, players: samplePlayers())
+
+        vm.startListening()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // When
+        vm.commitScores()
+
+        // Then
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched.count == 1)
+        #expect(fetched[0].playerID == "player-jake")
+        #expect(fetched[0].strokeCount == 4)
+    }
+
+    // MARK: - 6.8: VoiceOver focus pauses timer
+
+    @Test("voiceOverFocus_pausesAutoCommitTimer")
+    func test_voiceOverFocus_pausesAutoCommitTimer() async throws {
+        // Given
+        let mock = MockVoiceRecognitionService()
+        mock.transcriptToReturn = "Mike 3"
+        let (_, context) = try makeContext()
+        let (vm, _) = makeVM(mock: mock, context: context, players: samplePlayers())
+
+        vm.startListening()
+        try await Task.sleep(for: .milliseconds(100))
+        guard case .confirming = vm.state else {
+            Issue.record("Setup: expected .confirming state")
+            return
+        }
+
+        // When — VoiceOver focuses on overlay
+        vm.isVoiceOverFocused = true
+        // Wait longer than 1.5s auto-commit window
+        try await Task.sleep(for: .seconds(2))
+
+        // Then — timer should have been cancelled; state is still .confirming, no scores committed
+        if case .confirming = vm.state { } else {
+            Issue.record("Expected .confirming (timer paused), got \(vm.state)")
+        }
+        let fetched = try context.fetch(FetchDescriptor<ScoreEvent>())
+        #expect(fetched.isEmpty)
+    }
+
+    // MARK: - 6.9: recognition error → .error state
+
+    @Test("startListening_recognitionError_setsErrorState")
+    func test_startListening_recognitionError_setsErrorState() async throws {
+        // Given
+        let mock = MockVoiceRecognitionService()
+        mock.errorToThrow = .microphonePermissionDenied
+        let (_, context) = try makeContext()
+        let (vm, _) = makeVM(mock: mock, context: context, players: samplePlayers())
+
+        // When
+        vm.startListening()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Then — use pattern matching (VoiceParseError is not Equatable)
+        if case .error(.microphonePermissionDenied) = vm.state {
+            // Expected — correct error case
+        } else {
+            Issue.record("Expected .error(.microphonePermissionDenied) state, got \(vm.state)")
+        }
+        #expect(vm.isTerminated == true)
+    }
+}

--- a/_bmad-output/implementation-artifacts/5-2-voice-confirmation-overlay-and-auto-commit.md
+++ b/_bmad-output/implementation-artifacts/5-2-voice-confirmation-overlay-and-auto-commit.md
@@ -1,6 +1,6 @@
 # Story 5.2: Voice Confirmation Overlay & Auto-Commit
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -24,54 +24,54 @@ so that scoring is fast and hands-free in the common case.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create `VoiceRecognitionServiceProtocol` for testability (AC: 6)
-  - [ ] 1.1: Create `HyzerApp/Protocols/VoiceRecognitionServiceProtocol.swift` — `@MainActor protocol VoiceRecognitionServiceProtocol: AnyObject` with `func recognize() async throws -> String` and `func stopListening()`
-  - [ ] 1.2: Conform existing `VoiceRecognitionService` to `VoiceRecognitionServiceProtocol`
-  - [ ] 1.3: Add `stopListening()` method to `VoiceRecognitionService` — stops `audioEngine`, cancels `recognitionTask`
+- [x] Task 1: Create `VoiceRecognitionServiceProtocol` for testability (AC: 6)
+  - [x] 1.1: Create `HyzerApp/Protocols/VoiceRecognitionServiceProtocol.swift` — `@MainActor protocol VoiceRecognitionServiceProtocol: AnyObject` with `func recognize() async throws -> String` and `func stopListening()`
+  - [x] 1.2: Conform existing `VoiceRecognitionService` to `VoiceRecognitionServiceProtocol`
+  - [x] 1.3: Add `stopListening()` method to `VoiceRecognitionService` — stops `audioEngine`, cancels `recognitionTask`
 
-- [ ] Task 2: Create `VoiceOverlayViewModel` (AC: 1, 2, 3, 4, 5, 6)
-  - [ ] 2.1: Create `HyzerApp/ViewModels/VoiceOverlayViewModel.swift` — `@MainActor @Observable final class`
-  - [ ] 2.2: Constructor injection: `voiceRecognitionService: any VoiceRecognitionServiceProtocol`, `scoringService: ScoringService`, `parser: VoiceParser`, `roundID: UUID`, `holeNumber: Int`, `reportedByPlayerID: UUID`, `players: [VoicePlayerEntry]`
-  - [ ] 2.3: Implement `startListening()` — calls `voiceRecognitionService.recognize()`, feeds transcript into `parser.parse()`, sets state to `.confirming`
-  - [ ] 2.4: Implement auto-commit timer — 1.5s countdown via `Task.sleep`, resets on correction, cancels on dismiss
-  - [ ] 2.5: Implement `correctScore(at index: Int, newStrokeCount: Int)` — updates the `ScoreCandidate` in the list, resets timer to 1.5s
-  - [ ] 2.6: Implement `commitScores()` — iterates `[ScoreCandidate]`, calls `scoringService.createScoreEvent()` for each, sets state to `.committed`
-  - [ ] 2.7: Implement `cancel()` — cancels timer, calls `stopListening()` if active, sets state to `.dismissed`
-  - [ ] 2.8: Implement VoiceOver timer pause — expose `isVoiceOverFocused: Bool` property, pause timer when `true`
-  - [ ] 2.9: State enum: `.idle`, `.listening`, `.confirming([ScoreCandidate])`, `.committed`, `.dismissed`, `.error(VoiceParseError)`
+- [x] Task 2: Create `VoiceOverlayViewModel` (AC: 1, 2, 3, 4, 5, 6)
+  - [x] 2.1: Create `HyzerApp/ViewModels/VoiceOverlayViewModel.swift` — `@MainActor @Observable final class`
+  - [x] 2.2: Constructor injection: `voiceRecognitionService: any VoiceRecognitionServiceProtocol`, `scoringService: ScoringService`, `parser: VoiceParser`, `roundID: UUID`, `holeNumber: Int`, `reportedByPlayerID: UUID`, `players: [VoicePlayerEntry]`
+  - [x] 2.3: Implement `startListening()` — calls `voiceRecognitionService.recognize()`, feeds transcript into `parser.parse()`, sets state to `.confirming`
+  - [x] 2.4: Implement auto-commit timer — 1.5s countdown via `Task.sleep`, resets on correction, cancels on dismiss
+  - [x] 2.5: Implement `correctScore(at index: Int, newStrokeCount: Int)` — updates the `ScoreCandidate` in the list, resets timer to 1.5s
+  - [x] 2.6: Implement `commitScores()` — iterates `[ScoreCandidate]`, calls `scoringService.createScoreEvent()` for each, sets state to `.committed`
+  - [x] 2.7: Implement `cancel()` — cancels timer, calls `stopListening()` if active, sets state to `.dismissed`
+  - [x] 2.8: Implement VoiceOver timer pause — expose `isVoiceOverFocused: Bool` property, pause timer when `true`
+  - [x] 2.9: State enum: `.idle`, `.listening`, `.confirming([ScoreCandidate])`, `.committed`, `.dismissed`, `.error(VoiceParseError)`
 
-- [ ] Task 3: Create `VoiceOverlayView` (AC: 1, 3, 4, 5)
-  - [ ] 3.1: Create `HyzerApp/Views/Scoring/VoiceOverlayView.swift` — translucent overlay (`.ultraThinMaterial`)
-  - [ ] 3.2: Title: "Scores heard" using `TypographyTokens.caption`, `Color.textSecondary`
-  - [ ] 3.3: Player-score rows — name (`TypographyTokens.h2`, `.textPrimary`), dotted leader, score (`TypographyTokens.scoreLarge`, SF Mono), 56pt row height, score color from par comparison
-  - [ ] 3.4: Auto-commit progress indicator — subtle linear progress bar or countdown ring, 1.5s duration, using `Color.accentPrimary`
-  - [ ] 3.5: "Tap to correct" hint text — `TypographyTokens.caption`, `Color.textSecondary`
-  - [ ] 3.6: Correction mode — tapped row expands inline number picker (1-10), same as `ScoreInputView` pattern
-  - [ ] 3.7: Explicit "Commit Scores" button for VoiceOver — visually de-emphasized (`textSecondary`), always present
-  - [ ] 3.8: Animations — slide up from bottom with `AnimationTokens.springStiff`, fade out on commit (0.2s), respect `accessibilityReduceMotion` via `AnimationCoordinator`
-  - [ ] 3.9: Listening state — waveform or pulsing mic indicator during active recording
+- [x] Task 3: Create `VoiceOverlayView` (AC: 1, 3, 4, 5)
+  - [x] 3.1: Create `HyzerApp/Views/Scoring/VoiceOverlayView.swift` — translucent overlay (`.ultraThinMaterial`)
+  - [x] 3.2: Title: "Scores heard" using `TypographyTokens.caption`, `Color.textSecondary`
+  - [x] 3.3: Player-score rows — name (`TypographyTokens.h2`, `.textPrimary`), dotted leader, score (`TypographyTokens.scoreLarge`, SF Mono), 56pt row height, score color from par comparison
+  - [x] 3.4: Auto-commit progress indicator — subtle linear progress bar or countdown ring, 1.5s duration, using `Color.accentPrimary`
+  - [x] 3.5: "Tap to correct" hint text — `TypographyTokens.caption`, `Color.textSecondary`
+  - [x] 3.6: Correction mode — tapped row expands inline number picker (1-10), same as `ScoreInputView` pattern
+  - [x] 3.7: Explicit "Commit Scores" button for VoiceOver — visually de-emphasized (`textSecondary`), always present
+  - [x] 3.8: Animations — slide up from bottom with `AnimationTokens.springStiff`, fade out on commit (0.2s), respect `accessibilityReduceMotion` via `AnimationCoordinator`
+  - [x] 3.9: Listening state — waveform or pulsing mic indicator during active recording
 
-- [ ] Task 4: Integrate into `ScorecardContainerView` (AC: 1, 2, 4)
-  - [ ] 4.1: Add microphone button to hole card UI — triggers `VoiceOverlayViewModel.startListening()`
-  - [ ] 4.2: Present `VoiceOverlayView` as an overlay (not sheet/modal) on `ScorecardContainerView`
-  - [ ] 4.3: On `.committed` — trigger `StandingsEngine.recompute()` and leaderboard pill pulse animation
-  - [ ] 4.4: Add `@State private var voiceOverlayViewModel: VoiceOverlayViewModel?` — presence drives overlay visibility
+- [x] Task 4: Integrate into `ScorecardContainerView` (AC: 1, 2, 4)
+  - [x] 4.1: Add microphone button to hole card UI — triggers `VoiceOverlayViewModel.startListening()`
+  - [x] 4.2: Present `VoiceOverlayView` as an overlay (not sheet/modal) on `ScorecardContainerView`
+  - [x] 4.3: On `.committed` — trigger `StandingsEngine.recompute()` and leaderboard pill pulse animation
+  - [x] 4.4: Add `@State private var voiceOverlayViewModel: VoiceOverlayViewModel?` — presence drives overlay visibility
 
-- [ ] Task 5: Wire `VoiceRecognitionService` into `AppServices` (AC: 6)
-  - [ ] 5.1: Add `let voiceRecognitionService: VoiceRecognitionService` to `AppServices`
-  - [ ] 5.2: Initialize in `AppServices.init()` — `self.voiceRecognitionService = VoiceRecognitionService()`
-  - [ ] 5.3: Pass to `VoiceOverlayViewModel` creation in `ScorecardContainerView`
+- [x] Task 5: Wire `VoiceRecognitionService` into `AppServices` (AC: 6)
+  - [x] 5.1: Add `let voiceRecognitionService: VoiceRecognitionService` to `AppServices`
+  - [x] 5.2: Initialize in `AppServices.init()` — `self.voiceRecognitionService = VoiceRecognitionService()`
+  - [x] 5.3: Pass to `VoiceOverlayViewModel` creation in `ScorecardContainerView`
 
-- [ ] Task 6: Write `VoiceOverlayViewModelTests` (AC: 1, 2, 3, 4, 5)
-  - [ ] 6.1: Create `HyzerAppTests/VoiceOverlayViewModelTests.swift` — `@MainActor @Suite`
-  - [ ] 6.2: Create `MockVoiceRecognitionService` implementing `VoiceRecognitionServiceProtocol` — configurable transcript return and error throwing
-  - [ ] 6.3: Test: `startListening` with successful transcript sets state to `.confirming` with correct `ScoreCandidate`s
-  - [ ] 6.4: Test: `commitScores` creates one ScoreEvent per candidate via `ScoringService`
-  - [ ] 6.5: Test: `correctScore` updates the candidate strokeCount and resets timer state
-  - [ ] 6.6: Test: `cancel` sets state to `.dismissed` and creates no ScoreEvents
-  - [ ] 6.7: Test: subset scoring — single player transcript only commits that player's score
-  - [ ] 6.8: Test: VoiceOver focus pauses timer (set `isVoiceOverFocused = true`, verify timer doesn't fire)
-  - [ ] 6.9: Test: recognition error sets state to `.error` with correct `VoiceParseError`
+- [x] Task 6: Write `VoiceOverlayViewModelTests` (AC: 1, 2, 3, 4, 5)
+  - [x] 6.1: Create `HyzerAppTests/VoiceOverlayViewModelTests.swift` — `@MainActor @Suite`
+  - [x] 6.2: Create `MockVoiceRecognitionService` implementing `VoiceRecognitionServiceProtocol` — configurable transcript return and error throwing
+  - [x] 6.3: Test: `startListening` with successful transcript sets state to `.confirming` with correct `ScoreCandidate`s
+  - [x] 6.4: Test: `commitScores` creates one ScoreEvent per candidate via `ScoringService`
+  - [x] 6.5: Test: `correctScore` updates the candidate strokeCount and resets timer state
+  - [x] 6.6: Test: `cancel` sets state to `.dismissed` and creates no ScoreEvents
+  - [x] 6.7: Test: subset scoring — single player transcript only commits that player's score
+  - [x] 6.8: Test: VoiceOver focus pauses timer (set `isVoiceOverFocused = true`, verify timer doesn't fire)
+  - [x] 6.9: Test: recognition error sets state to `.error` with correct `VoiceParseError`
 
 ## Dev Notes
 
@@ -340,10 +340,33 @@ final class MockVoiceRecognitionService: VoiceRecognitionServiceProtocol {
 
 ### Agent Model Used
 
-{{agent_model_name_version}}
+claude-sonnet-4-6
 
 ### Debug Log References
 
 ### Completion Notes List
 
+- Created `VoiceRecognitionServiceProtocol` in `HyzerApp/Protocols/` with `recognize()` and `stopListening()` methods; `VoiceRecognitionService` now conforms and exposes `stopListening()` publicly.
+- `VoiceOverlayViewModel` is `@MainActor @Observable` with full state machine (idle → listening → confirming → committed/dismissed/error), 1.5s auto-commit timer via `Task.sleep`, VoiceOver timer-pause via `isVoiceOverFocused`, and `isTerminated`/`isCommitted` boolean flags for `Equatable` SwiftUI observation.
+- `VoiceOverlayView` uses `.ultraThinMaterial`, dotted leader rows (56pt height), a `GeometryReader`-based linear progress bar, listening waveform state, inline `ScoreInputView` correction, and an explicit "Commit Scores" button for VoiceOver. Reduce-motion respects `AnimationCoordinator`.
+- `ScorecardContainerView` now has a mic toolbar button (trailing, alongside the menu), `voiceOverlayContent` `@ViewBuilder` for the overlay, and `handleVoiceOverlayTerminated` method to avoid Swift type-checker complexity. Extracted `trailingToolbarContent` for the same reason.
+- `AppServices` gets `voiceRecognitionService: VoiceRecognitionService` property and init line.
+- 9 new `VoiceOverlayViewModelTests` written and passing; `MockVoiceRecognitionService` added in `HyzerAppTests/Mocks/`.
+- Fixed pre-existing test failure in `ICloudIdentityResolutionTests` (missing `cloudKitClient`/`networkMonitor` args) with local stub conformances.
+- All 97 HyzerApp tests pass; 166 HyzerKit tests continue passing; SwiftLint clean.
+
 ### File List
+
+**New files:**
+- `HyzerApp/Protocols/VoiceRecognitionServiceProtocol.swift`
+- `HyzerApp/ViewModels/VoiceOverlayViewModel.swift`
+- `HyzerApp/Views/Scoring/VoiceOverlayView.swift`
+- `HyzerAppTests/VoiceOverlayViewModelTests.swift`
+- `HyzerAppTests/Mocks/MockVoiceRecognitionService.swift`
+
+**Modified files:**
+- `HyzerApp/App/AppServices.swift`
+- `HyzerApp/Services/VoiceRecognitionService.swift`
+- `HyzerApp/Views/Scoring/ScorecardContainerView.swift`
+- `HyzerAppTests/ICloudIdentityResolutionTests.swift` (pre-existing bug fix: missing stub args)
+- `HyzerApp.xcodeproj/project.pbxproj` (regenerated by xcodegen for new directories)

--- a/_bmad-output/implementation-artifacts/5-2-voice-confirmation-overlay-and-auto-commit.md
+++ b/_bmad-output/implementation-artifacts/5-2-voice-confirmation-overlay-and-auto-commit.md
@@ -351,9 +351,18 @@ claude-sonnet-4-6
 - `VoiceOverlayView` uses `.ultraThinMaterial`, dotted leader rows (56pt height), a `GeometryReader`-based linear progress bar, listening waveform state, inline `ScoreInputView` correction, and an explicit "Commit Scores" button for VoiceOver. Reduce-motion respects `AnimationCoordinator`.
 - `ScorecardContainerView` now has a mic toolbar button (trailing, alongside the menu), `voiceOverlayContent` `@ViewBuilder` for the overlay, and `handleVoiceOverlayTerminated` method to avoid Swift type-checker complexity. Extracted `trailingToolbarContent` for the same reason.
 - `AppServices` gets `voiceRecognitionService: VoiceRecognitionService` property and init line.
-- 9 new `VoiceOverlayViewModelTests` written and passing; `MockVoiceRecognitionService` added in `HyzerAppTests/Mocks/`.
+- 8 `VoiceOverlayViewModelTests` written and passing (includes auto-commit timer test); `MockVoiceRecognitionService` added in `HyzerAppTests/Mocks/`.
 - Fixed pre-existing test failure in `ICloudIdentityResolutionTests` (missing `cloudKitClient`/`networkMonitor` args) with local stub conformances.
-- All 97 HyzerApp tests pass; 166 HyzerKit tests continue passing; SwiftLint clean.
+- All 98 HyzerApp tests pass; 166 HyzerKit tests continue passing; SwiftLint clean.
+
+### Code Review Fixes (BMAD Adversarial Review)
+
+- **H1 (VoiceOver timer-pause):** Replaced broken `@AccessibilityFocusState` container tracking with `UIAccessibility.isVoiceOverRunning` check on appear — VoiceOver users now have the timer permanently paused, using the explicit "Commit Scores" button instead.
+- **H2 (Progress bar reset):** Added `timerResetCount` observable property to ViewModel; View now observes it via `.onChange` to reset progress bar animation when timer restarts after corrections. Rewrote `startProgress()` to properly reset animation via two-frame update.
+- **H3 (VoiceOver announcement):** Added `announceScores()` helper that posts all parsed scores via `AccessibilityNotification.Announcement` on overlay appear when VoiceOver is active.
+- **M1 (Misleading error):** Improved comment in `commitScores()` catch block to document the compromise — ScoringService persistence errors mapped to `.recognitionUnavailable` because `VoiceParseError` (HyzerKit) has no persistence case.
+- **M2 (Missing timer test):** Added `test_autoCommitTimer_firesAfterDelay_commitsScores` — verifies 1.5s auto-commit timer fires and commits ScoreEvents.
+- **M3 (Audio engine cleanup):** Added `deinit` to `VoiceOverlayViewModel` with `nonisolated(unsafe)` properties for Swift 6 compatibility — cancels timer and schedules `stopListening()` via `@MainActor` Task hop.
 
 ### File List
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -64,7 +64,7 @@ stories:
     epic: 5
   "5.2":
     title: "Voice Confirmation Overlay & Auto-Commit"
-    status: in-progress
+    status: review
     epic: 5
   "5.3":
     title: "Partial & Failed Recognition Handling"


### PR DESCRIPTION
Closes #16

## User Story
As a disc golfer recording scores, I want to say player names and scores out loud and see them instantly with a brief auto-commit window, so I can verify accuracy before scores are saved without stopping the flow of the game.

## Changes

```
 HyzerApp.xcodeproj/project.pbxproj                 |  36 +++
 HyzerApp/App/AppServices.swift                     |   2 +
 .../VoiceRecognitionServiceProtocol.swift           |  18 ++
 HyzerApp/Services/VoiceRecognitionService.swift     |   9 +-
 HyzerApp/ViewModels/VoiceOverlayViewModel.swift     | 203 +++++++++++++++
 .../Views/Scoring/ScorecardContainerView.swift      |  95 ++++++-
 HyzerApp/Views/Scoring/VoiceOverlayView.swift       | 230 +++++++++++++++++
 HyzerAppTests/ICloudIdentityResolutionTests.swift   |  22 +-
 .../Mocks/MockVoiceRecognitionService.swift         |  25 ++
 HyzerAppTests/VoiceOverlayViewModelTests.swift      | 272 +++++++++++++++++++++
 12 files changed, 981 insertions(+), 65 deletions(-)
```

### New Files
- **`HyzerApp/Protocols/VoiceRecognitionServiceProtocol.swift`** — `@MainActor` protocol with `recognize()` and `stopListening()` for testability
- **`HyzerApp/ViewModels/VoiceOverlayViewModel.swift`** — Full state machine (`.idle → .listening → .confirming → .committed/.dismissed/.error`) with 1.5s auto-commit timer, VoiceOver timer-pause, and inline correction support
- **`HyzerApp/Views/Scoring/VoiceOverlayView.swift`** — Translucent `.ultraThinMaterial` overlay with dotted leader rows (56pt), `accentPrimary` progress bar, listening waveform state, inline `ScoreInputView` correction, reduce-motion support
- **`HyzerAppTests/VoiceOverlayViewModelTests.swift`** — 8 tests covering all ACs + auto-commit timer verification
- **`HyzerAppTests/Mocks/MockVoiceRecognitionService.swift`** — Configurable test double

### Modified Files
- **`AppServices.swift`** — Added `voiceRecognitionService: VoiceRecognitionService` property
- **`VoiceRecognitionService.swift`** — Protocol conformance + public `stopListening()` method
- **`ScorecardContainerView.swift`** — Mic toolbar button, `VoiceOverlayView` overlay, `voicePlayerEntries` computed property, leaderboard recompute on commit
- **`ICloudIdentityResolutionTests.swift`** — Fixed pre-existing build failure (missing `cloudKitClient`/`networkMonitor` stub args)

## Test Coverage
- `startListening` with successful transcript → `.confirming` with correct `ScoreCandidate`s
- `commitScores` → one `ScoreEvent` per candidate created via `ScoringService`
- `correctScore` → updates stroke count, resets auto-commit timer
- `cancel` → `.dismissed` state, no ScoreEvents, `stopListening()` called once
- Subset scoring → single-player transcript commits only that player
- VoiceOver focus → auto-commit timer paused for 2s+ without committing
- Auto-commit timer → fires after 1.5s and commits scores automatically
- Recognition error → `.error(.microphonePermissionDenied)` state

**98 HyzerApp tests pass. 166 HyzerKit tests pass. SwiftLint clean.**

---
_Developed via BMAD workflow_