### PR TITLE
fix(build): add iPad orientations and watch icon for TestFlight

### DIFF
--- a/HyzerApp.xcodeproj/project.pbxproj
+++ b/HyzerApp.xcodeproj/project.pbxproj
@@ -764,6 +764,7 @@
 				CODE_SIGN_ENTITLEMENTS = HyzerWatch/App/HyzerWatch.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleIconName = AppIcon;
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.shotcowboystyle.hyzerapp;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks @executable_path/../../Frameworks";
@@ -865,6 +866,7 @@
 				CODE_SIGN_ENTITLEMENTS = HyzerWatch/App/HyzerWatch.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleIconName = AppIcon;
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.shotcowboystyle.hyzerapp;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks @executable_path/../../Frameworks";

--- a/HyzerApp/App/Info.plist
+++ b/HyzerApp/App/Info.plist
@@ -28,5 +28,16 @@
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 </dict>
 </plist>

--- a/project.yml
+++ b/project.yml
@@ -40,6 +40,13 @@ targets:
       path: HyzerApp/App/Info.plist
       properties:
         UILaunchScreen: {}
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+        UISupportedInterfaceOrientations~ipad:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
         UIBackgroundModes:
           - remote-notification
         NSMicrophoneUsageDescription: "HyzerApp uses the microphone to hear player names and scores for hands-free scoring."
@@ -76,6 +83,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.shotcowboystyle.hyzerapp.watchkitapp
         CODE_SIGN_ENTITLEMENTS: HyzerWatch/App/HyzerWatch.entitlements
         GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_CFBundleIconName: AppIcon
         INFOPLIST_KEY_WKWatchKitApp: YES
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: "1.0"


### PR DESCRIPTION
## Summary

- Add `UISupportedInterfaceOrientations` (portrait) and `UISupportedInterfaceOrientations~ipad` (all orientations) to satisfy iPad multitasking bundle validation
- Add `INFOPLIST_KEY_CFBundleIconName: AppIcon` to HyzerWatch target so the generated Info.plist includes `CFBundleIconName`

Fixes two App Store Connect upload validation errors blocking TestFlight distribution.

## Test plan

- [x] 269 tests pass
- [x] `xcodegen generate` succeeds
- [ ] Archive and upload to App Store Connect passes validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)