### PR TITLE
fix(build): resolve all Xcode build warnings

### DIFF
--- a/HyzerApp/Services/LiveCloudKitClient.swift
+++ b/HyzerApp/Services/LiveCloudKitClient.swift
@@ -74,6 +74,7 @@ struct LiveCloudKitClient: CloudKitClient, Sendable {
         let subscription = CKQuerySubscription(
             recordType: recordType,
             predicate: predicate,
+            subscriptionID: "\(recordType)-creation",
             options: [.firesOnRecordCreation]
         )
         let info = CKSubscription.NotificationInfo()

--- a/HyzerApp/ViewModels/VoiceOverlayViewModel.swift
+++ b/HyzerApp/ViewModels/VoiceOverlayViewModel.swift
@@ -66,9 +66,9 @@ final class VoiceOverlayViewModel {
 
     // MARK: - Timer
 
-    // nonisolated(unsafe): allows deinit to call cancel() without a main-actor hop.
-    // All writes happen on @MainActor; deinit only calls cancel().
-    nonisolated(unsafe) private var timerTask: Task<Void, Never>?
+    // ObservationIgnored + nonisolated: allows deinit to call cancel() without a main-actor hop.
+    // All writes happen on @MainActor; deinit only calls cancel(). No observation tracking needed.
+    @ObservationIgnored nonisolated(unsafe) private var timerTask: Task<Void, Never>?
 
     /// When `true` (VoiceOver focus on overlay), the auto-commit timer is paused.
     var isVoiceOverFocused: Bool = false {

--- a/HyzerApp/Views/Scoring/ScorecardContainerView.swift
+++ b/HyzerApp/Views/Scoring/ScorecardContainerView.swift
@@ -289,7 +289,7 @@ struct ScorecardContainerView: View {
     private func finishRoundForced() {
         guard let vm = viewModel else { return }
         do {
-            try vm.finishRound(force: true)
+            _ = try vm.finishRound(force: true)
             // Post-completion navigation: HomeView's @Query no longer includes this round,
             // so ScoringTabView automatically switches back to the "Start Round" state.
         } catch {

--- a/HyzerKit/Sources/HyzerKit/Communication/WatchVoiceViewModel.swift
+++ b/HyzerKit/Sources/HyzerKit/Communication/WatchVoiceViewModel.swift
@@ -37,8 +37,9 @@ public final class WatchVoiceViewModel {
     private let playerEntries: [VoicePlayerEntry]
     private let connectivityClient: any WatchConnectivityClient
 
-    // nonisolated(unsafe): deinit is nonisolated; all actual use is on @MainActor.
-    nonisolated(unsafe) private var timerTask: Task<Void, Never>?
+    // ObservationIgnored + nonisolated: deinit is nonisolated; all actual use is on @MainActor.
+    // Timer task doesn't need observation tracking.
+    @ObservationIgnored nonisolated(unsafe) private var timerTask: Task<Void, Never>?
 
     // MARK: - Init
 
@@ -134,7 +135,7 @@ public final class WatchVoiceViewModel {
         timerTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(1.5))
             guard !Task.isCancelled else { return }
-            await self?.confirmScores()
+            self?.confirmScores()
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `@ObservationIgnored` to `nonisolated(unsafe)` timerTask properties in `VoiceOverlayViewModel` and `WatchVoiceViewModel` to prevent conflict with `@Observable` macro
- Use non-deprecated `CKQuerySubscription` initializer with explicit `subscriptionID` in `LiveCloudKitClient`
- Discard unused `FinishRoundResult` in `ScorecardContainerView`
- Remove unnecessary `await` on synchronous `confirmScores()` call in `WatchVoiceViewModel`

## Test plan
- [x] `xcodebuild build` passes with zero warnings and zero errors
- [x] `swift test --package-path HyzerKit` — all 269 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)