### PR TITLE
fix(test): address P0/P1 test quality quick wins from TEA review

### DIFF
--- a/HyzerAppTests/Fixtures/TestPolling.swift
+++ b/HyzerAppTests/Fixtures/TestPolling.swift
@@ -6,16 +6,21 @@ import Foundation
 /// polling loop that terminates as soon as the condition is met — faster on fast machines,
 /// still reliable on slow CI.
 ///
+/// NOTE: Canonical implementation lives in HyzerKitTests/Fixtures/TestPolling.swift.
+/// This copy must stay in sync — both targets need their own copy because test targets
+/// cannot share source files across module boundaries.
+///
 /// - Parameters:
 ///   - timeout: Maximum time to wait before returning `false`. Default 2 seconds.
 ///   - pollInterval: Time between polls. Default 10ms.
 ///   - condition: Closure evaluated each poll cycle. Return `true` to stop waiting.
 /// - Returns: `true` if the condition was met within timeout, `false` otherwise.
 @discardableResult
+@MainActor
 func awaitCondition(
     timeout: Duration = .seconds(2),
     pollInterval: Duration = .milliseconds(10),
-    _ condition: @Sendable () async throws -> Bool
+    _ condition: () async throws -> Bool
 ) async rethrows -> Bool {
     let deadline = ContinuousClock.now + timeout
     while ContinuousClock.now < deadline {

--- a/HyzerKit/Tests/HyzerKitTests/Communication/WatchVoiceViewModelTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/Communication/WatchVoiceViewModelTests.swift
@@ -205,15 +205,13 @@ struct WatchVoiceViewModelTests {
         let result = WatchVoiceResult(result: .success(candidates), holeNumber: holeNumber, roundID: roundID)
         vm.handleVoiceResult(result)
 
-        // Poll for committed state — allow generous budget for CI scheduling variance.
-        var elapsed = 0
-        while elapsed < 40 {
-            if case .committed = vm.state { break }
-            try await Task.sleep(for: .milliseconds(100))
-            elapsed += 1
+        // Use deterministic polling — exits as soon as condition is met, with 4s safety budget.
+        let committed = await awaitCondition(timeout: .seconds(4)) {
+            if case .committed = vm.state { return true }
+            return false
         }
 
-        guard case .committed = vm.state else {
+        guard committed else {
             Issue.record("Expected .committed state after auto-commit timer (4s budget)")
             return
         }

--- a/HyzerKit/Tests/HyzerKitTests/SyncEngineTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/SyncEngineTests.swift
@@ -168,6 +168,7 @@ struct SyncEngineTests {
         // Assert: ScoreEvent now exists locally (poll until background save merges)
         let remoteID = remoteEvent.id
         await awaitCondition {
+            // Safe: fetch failure in polling means condition not yet met; empty fallback retries
             let events = (try? context.fetch(FetchDescriptor<ScoreEvent>())) ?? []
             return events.contains { $0.id == remoteID }
         }
@@ -202,6 +203,7 @@ struct SyncEngineTests {
         // Poll until background save merges (dedup check)
         let eventID = event.id
         await awaitCondition {
+            // Safe: fetch failure in polling means condition not yet met; empty fallback retries
             let events = (try? context.fetch(FetchDescriptor<ScoreEvent>())) ?? []
             return !events.isEmpty && events.filter({ $0.id == eventID }).count == 1
         }

--- a/HyzerKit/Tests/HyzerKitTests/SyncRecoveryTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/SyncRecoveryTests.swift
@@ -134,6 +134,7 @@ struct SyncRecoveryTests {
         let id1 = event1.id.uuidString
         let id2 = event2.id.uuidString
         await awaitCondition {
+            // Safe: fetch failure in polling means condition not yet met; empty fallback retries
             let allMeta = (try? context.fetch(FetchDescriptor<SyncMetadata>())) ?? []
             let m1 = allMeta.first { $0.recordID == id1 }
             let m2 = allMeta.first { $0.recordID == id2 }
@@ -212,6 +213,7 @@ struct SyncRecoveryTests {
         // Poll until exactly one copy of the event exists in the local store
         let eventID = event.id
         await awaitCondition {
+            // Safe: fetch failure in polling means condition not yet met; empty fallback retries
             let events = (try? context.fetch(FetchDescriptor<ScoreEvent>())) ?? []
             return events.filter { $0.id == eventID }.count == 1
         }

--- a/HyzerKit/Tests/HyzerKitTests/SyncSchedulerTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/SyncSchedulerTests.swift
@@ -148,6 +148,7 @@ struct SyncSchedulerTests {
         // Poll until background context saves and merges the remote event
         let remoteID = remoteEvent.id
         await awaitCondition {
+            // Safe: fetch failure in polling means condition not yet met; empty fallback retries
             let events = (try? context.fetch(FetchDescriptor<ScoreEvent>())) ?? []
             return events.contains { $0.id == remoteID }
         }


### PR DESCRIPTION
## Summary
Addresses the top 3 findings from the TEA test quality review (`_bmad-output/test-artifacts/test-review.md`, score 88/100):

- **P0: Unify TestPolling.swift** — Both HyzerKitTests and HyzerAppTests copies now share identical `@MainActor` signatures with a sync note to prevent future drift
- **P1: Add `try?` justification comments** — 5 polling fetch sites in `SyncEngineTests`, `SyncRecoveryTests`, and `SyncSchedulerTests` now have the required `// Safe:` comments per project coding standards
- **P1: Replace flaky Task.sleep** — `WatchVoiceViewModelTests` auto-commit timer test now uses `awaitCondition(timeout: .seconds(4))` instead of a 40-iteration `Task.sleep(for: .milliseconds(100))` loop

## Test plan
- [x] `swift test --package-path HyzerKit` — all 269 tests pass (including refactored timer test)
- [x] `xcodebuild build` — clean build, zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)