### PR TITLE
fix(voice): configure AVAudioSession before accessing audio engine input node

### DIFF
--- a/HyzerApp/Services/VoiceRecognitionService.swift
+++ b/HyzerApp/Services/VoiceRecognitionService.swift
@@ -34,6 +34,12 @@ public final class VoiceRecognitionService: VoiceRecognitionServiceProtocol {
             throw VoiceParseError.recognitionUnavailable
         }
 
+        do {
+            try configureAudioSession()
+        } catch {
+            throw VoiceParseError.recognitionUnavailable
+        }
+
         return try await withCheckedThrowingContinuation { continuation in
             let request = SFSpeechAudioBufferRecognitionRequest()
             request.requiresOnDeviceRecognition = true
@@ -49,6 +55,7 @@ public final class VoiceRecognitionService: VoiceRecognitionServiceProtocol {
             do {
                 try audioEngine.start()
             } catch {
+                deactivateAudioSession()
                 continuation.resume(throwing: VoiceParseError.recognitionUnavailable)
                 return
             }
@@ -94,6 +101,19 @@ public final class VoiceRecognitionService: VoiceRecognitionServiceProtocol {
         audioEngine.inputNode.removeTap(onBus: 0)
         recognitionTask?.cancel()
         recognitionTask = nil
+        deactivateAudioSession()
+    }
+
+    private func configureAudioSession() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
+    }
+
+    private func deactivateAudioSession() {
+        // Safe to ignore: deactivation failure is non-fatal — the system reclaims
+        // the session automatically when no audio routes are active.
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
     // MARK: - Permissions


### PR DESCRIPTION
## Summary
- App crashed when tapping the microphone icon because `AVAudioEngine.inputNode` was accessed without an active `AVAudioSession` configured for recording
- Added `configureAudioSession()` call (sets `.record` category, `.measurement` mode) before accessing the input node
- Added `deactivateAudioSession()` cleanup in `stopAudioEngine()` and on `audioEngine.start()` failure

## Test plan
- [ ] Tap mic icon on scorecard — should show listening overlay without crashing
- [ ] Deny microphone permission — should show error state, not crash
- [ ] Complete voice recognition flow end-to-end
- [ ] Verify audio session deactivates after recognition completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)