### PR TITLE
fix(p0): address pre-TestFlight technical debt

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -68,3 +68,9 @@ custom_rules:
     regex: 'duration\s*:\s*0\.\d+'
     message: "Use AnimationTokens presets (springStiff, springGentle) or explicit constants instead of hardcoded durations"
     severity: warning
+
+  unbounded_fetch_descriptor:
+    name: "Unbounded FetchDescriptor"
+    regex: 'FetchDescriptor<[A-Za-z]+>\(\s*\)'
+    message: "FetchDescriptor with no arguments fetches the entire table and grows unbounded with data. Add fetchLimit or a predicate. If the full scan is intentional (e.g. fetch-all-and-filter workaround), add a comment explaining why."
+    severity: warning

--- a/HyzerApp.xcodeproj/project.pbxproj
+++ b/HyzerApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		42CF8E0631A83A8D502FE1D9 /* PlayerHoleBreakdownViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4804F2B7A8D14716181BBCED /* PlayerHoleBreakdownViewModel.swift */; };
 		4355F22606C5C352805D9DE6 /* LeaderboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CB2EA23B021251B93ADEE /* LeaderboardViewModel.swift */; };
 		43AA274D5D9454EBF1D658F2 /* AppServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DFB1F9AC07FE1B019DC349 /* AppServices.swift */; };
+		47C4A3442BBC7CE9DCFA5A7D /* MetricKitObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3155F75FB2C622BF915D9898 /* MetricKitObserver.swift */; };
 		50C17EC7DBFF7B4F6F7C3FE2 /* WatchVoiceOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB09CCB4D01B9EF25459980 /* WatchVoiceOverlayView.swift */; };
 		5105D60E9D7E55AB98453D0C /* CourseListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D567388ADB189B6F28DF15C2 /* CourseListView.swift */; };
 		5537A2C938E1825E0FF939E8 /* PlayerHoleBreakdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711AA43585D959E6B35DC045 /* PlayerHoleBreakdownView.swift */; };
@@ -125,6 +126,7 @@
 		2CC2A9F18AFB9B84DAD30F16 /* HyzerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyzerApp.swift; sourceTree = "<group>"; };
 		2D7D740D79452CC43CCAA46F /* DiscrepancyLoadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscrepancyLoadTests.swift; sourceTree = "<group>"; };
 		2F15A3320EA3B193B04FB19E /* HistoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListView.swift; sourceTree = "<group>"; };
+		3155F75FB2C622BF915D9898 /* MetricKitObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricKitObserver.swift; sourceTree = "<group>"; };
 		39EF3E5C7FF81BCA34D9DC08 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		3D25A260E0DBDD3FFD58E9A3 /* SyncIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncIndicatorView.swift; sourceTree = "<group>"; };
 		3EB09CCB4D01B9EF25459980 /* WatchVoiceOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceOverlayView.swift; sourceTree = "<group>"; };
@@ -450,6 +452,7 @@
 				99BEC27ED6A658066DE3B9F9 /* LiveCloudKitClient.swift */,
 				41F4A3FDA72AE73321E44E1B /* LiveICloudIdentityProvider.swift */,
 				D0EAF2CE8A78AA9A463585BB /* LiveNetworkMonitor.swift */,
+				3155F75FB2C622BF915D9898 /* MetricKitObserver.swift */,
 				9CF27AB5613FDD66774D32B9 /* PhoneConnectivityService.swift */,
 				751B4A4FAE27078A43BE3A3F /* VoiceRecognitionService.swift */,
 			);
@@ -697,6 +700,7 @@
 				7823F1D6F90939B940EFAD1F /* LiveCloudKitClient.swift in Sources */,
 				A42D386C8B0A344A48653392 /* LiveICloudIdentityProvider.swift in Sources */,
 				689356B498827861015A14A4 /* LiveNetworkMonitor.swift in Sources */,
+				47C4A3442BBC7CE9DCFA5A7D /* MetricKitObserver.swift in Sources */,
 				A85DE61AD542BF166999182B /* OnboardingView.swift in Sources */,
 				AB7ECE958B351A749ED816BB /* OnboardingViewModel.swift in Sources */,
 				915770F21BA9C30CDAC86B2B /* PhoneConnectivityService.swift in Sources */,

--- a/HyzerApp/App/AppServices.swift
+++ b/HyzerApp/App/AppServices.swift
@@ -73,8 +73,13 @@ final class AppServices {
     private static func resolveLocalPlayerID(from context: ModelContext) -> UUID? {
         var descriptor = FetchDescriptor<Player>()
         descriptor.fetchLimit = 1
-        let players = try? context.fetch(descriptor)
-        return players?.first?.id
+        do {
+            return try context.fetch(descriptor).first?.id
+        } catch {
+            Logger(subsystem: "com.shotcowboystyle.hyzerapp", category: "AppServices")
+                .error("resolveLocalPlayerID failed: \(error)")
+            return nil
+        }
     }
 
     // MARK: - Sync

--- a/HyzerApp/App/HyzerApp.swift
+++ b/HyzerApp/App/HyzerApp.swift
@@ -11,6 +11,7 @@ struct HyzerApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
 
     init() {
+        MetricKitObserver.shared.register()
         let container = Self.makeModelContainer()
         let networkMonitor = LiveNetworkMonitor()
         appServices = AppServices(
@@ -117,6 +118,8 @@ struct HyzerApp: App {
         let walURL = storeURL.appendingPathExtension("wal")
         let shmURL = storeURL.appendingPathExtension("shm")
         for url in [storeURL, walURL, shmURL] {
+            // Safe to ignore: files may not exist (WAL/SHM are only present in WAL mode).
+            // Cleanup failure is non-fatal — makeModelContainer retries on next launch.
             try? fm.removeItem(at: url)
         }
     }

--- a/HyzerApp/Services/MetricKitObserver.swift
+++ b/HyzerApp/Services/MetricKitObserver.swift
@@ -1,0 +1,65 @@
+import MetricKit
+import os.log
+
+/// Receives MetricKit payloads and crash diagnostics delivered by the OS.
+///
+/// MetricKit collects system performance data (launch time, memory, CPU, battery, hangs)
+/// and crash diagnostics. Payloads are delivered once per day on the first launch
+/// after the reporting period ends, or the first launch after a crash.
+///
+/// Usage: call `MetricKitObserver.shared.register()` once at app startup.
+final class MetricKitObserver: NSObject, MXMetricManagerSubscriber {
+    static let shared = MetricKitObserver()
+
+    private let logger = Logger(subsystem: "com.shotcowboystyle.hyzerapp", category: "MetricKit")
+
+    private override init() {}
+
+    func register() {
+        MXMetricManager.shared.add(self)
+        logger.info("MetricKitObserver registered")
+    }
+
+    // MARK: - MXMetricManagerSubscriber
+
+    func didReceive(_ payloads: [MXMetricPayload]) {
+        for payload in payloads {
+            logger.info("MetricKit metrics received for period \(payload.timeStampBegin) – \(payload.timeStampEnd)")
+            writePayloadToFile(payload.jsonRepresentation(), prefix: "metrics")
+        }
+    }
+
+    @available(iOS 14, *)
+    func didReceive(_ payloads: [MXDiagnosticPayload]) {
+        for payload in payloads {
+            let json = payload.jsonRepresentation()
+            writePayloadToFile(json, prefix: "diagnostic")
+
+            if let crashes = payload.crashDiagnostics, !crashes.isEmpty {
+                logger.critical("Crash diagnostic received — \(crashes.count) crash(es) since last launch")
+            }
+            if let hangs = payload.hangDiagnostics, !hangs.isEmpty {
+                logger.error("Hang diagnostic received — \(hangs.count) hang(s) since last launch")
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func writePayloadToFile(_ data: Data, prefix: String) {
+        guard let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            logger.error("MetricKit: cannot resolve applicationSupportDirectory")
+            return
+        }
+        let logsDir = dir.appendingPathComponent("MetricKitLogs", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
+            let timestamp = Int(Date().timeIntervalSince1970)
+            let fileURL = logsDir.appendingPathComponent("\(prefix)-\(timestamp).json")
+            try data.write(to: fileURL)
+            logger.info("MetricKit payload written to \(fileURL.lastPathComponent)")
+        } catch {
+            logger.error("MetricKit: failed to write payload: \(error)")
+        }
+    }
+}

--- a/HyzerApp/ViewModels/HistoryListViewModel.swift
+++ b/HyzerApp/ViewModels/HistoryListViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import SwiftData
+import os.log
 import HyzerKit
 
 /// View-ready data for one history round card.
@@ -34,6 +35,7 @@ final class HistoryListViewModel {
     private let modelContext: ModelContext
     private let standingsEngine: StandingsEngine
     private let dateFormatter: DateFormatter
+    private let logger = Logger(subsystem: "com.shotcowboystyle.hyzerapp", category: "HistoryListViewModel")
     let currentPlayerID: String
 
     /// Cached card data keyed by round ID. Populated lazily as cards appear on screen.
@@ -67,7 +69,13 @@ final class HistoryListViewModel {
 
         let courseIDLocal = round.courseID
         let descriptor = FetchDescriptor<Course>(predicate: #Predicate { $0.id == courseIDLocal })
-        let courseName = (try? modelContext.fetch(descriptor))?.first?.name ?? "Unknown Course"
+        let courseName: String
+        do {
+            courseName = try modelContext.fetch(descriptor).first?.name ?? "Unknown Course"
+        } catch {
+            logger.error("HistoryListViewModel: course fetch failed for round \(round.id): \(error)")
+            courseName = "Unknown Course"
+        }
 
         let formattedDate = dateFormatter.string(from: round.completedAt ?? Date())
 

--- a/HyzerApp/ViewModels/VoiceOverlayViewModel.swift
+++ b/HyzerApp/ViewModels/VoiceOverlayViewModel.swift
@@ -231,6 +231,7 @@ final class VoiceOverlayViewModel {
         timerTask?.cancel()
         timerResetCount += 1
         timerTask = Task { [weak self] in
+            // CancellationError is the normal cancellation signal from timerTask?.cancel(); isCancelled guard below handles it.
             try? await Task.sleep(for: .seconds(AnimationTokens.autoCommitDuration))
             guard !Task.isCancelled else { return }
             self?.commitScores()

--- a/HyzerApp/Views/Scoring/VoiceOverlayView.swift
+++ b/HyzerApp/Views/Scoring/VoiceOverlayView.swift
@@ -321,6 +321,7 @@ struct VoiceOverlayView: View {
         let descriptions = candidates.map { "\($0.displayName), \($0.strokeCount)" }.joined(separator: ". ")
         let announcement = "Voice scores confirmed. \(descriptions). Tap any score to correct."
         Task { @MainActor in
+            // Delay lets the UI settle before VoiceOver speaks; CancellationError is harmless if Task is deallocated.
             try? await Task.sleep(for: .milliseconds(500))
             AccessibilityNotification.Announcement(announcement).post()
         }
@@ -332,6 +333,7 @@ struct VoiceOverlayView: View {
             "\(unresolvedCount) unresolved. " +
             "Tap the highlighted names to select the correct player."
         Task { @MainActor in
+            // Delay lets the UI settle before VoiceOver speaks; CancellationError is harmless if Task is deallocated.
             try? await Task.sleep(for: .milliseconds(500))
             AccessibilityNotification.Announcement(announcement).post()
         }
@@ -340,6 +342,7 @@ struct VoiceOverlayView: View {
     private func announceFailure() {
         let announcement = "Couldn't understand. Double-tap Try Again to retry, or Cancel to return to scoring."
         Task { @MainActor in
+            // Delay lets the UI settle before VoiceOver speaks; CancellationError is harmless if Task is deallocated.
             try? await Task.sleep(for: .milliseconds(500))
             AccessibilityNotification.Announcement(announcement).post()
         }

--- a/HyzerKit/Sources/HyzerKit/Communication/WatchVoiceViewModel.swift
+++ b/HyzerKit/Sources/HyzerKit/Communication/WatchVoiceViewModel.swift
@@ -133,6 +133,7 @@ public final class WatchVoiceViewModel {
     private func startAutoCommitTimer() {
         timerTask?.cancel()
         timerTask = Task { [weak self] in
+            // CancellationError is the normal cancellation signal from timerTask?.cancel(); isCancelled guard below handles it.
             try? await Task.sleep(for: .seconds(1.5))
             guard !Task.isCancelled else { return }
             self?.confirmScores()

--- a/HyzerKit/Sources/HyzerKit/Sync/SyncEngine.swift
+++ b/HyzerKit/Sources/HyzerKit/Sync/SyncEngine.swift
@@ -117,8 +117,13 @@ public actor SyncEngine: ModelActor {
         }
         guard !pendingEntries.isEmpty else { return }
 
-        // Hoist event fetch outside loop and build O(1) lookup dictionary
-        let allEvents = fetchAllScoreEvents()
+        // Scope event fetch to only ScoreEvent IDs referenced by pending entries
+        let pendingEventIDs = Set(
+            pendingEntries
+                .filter { $0.recordType == ScoreEventRecord.recordType }
+                .compactMap { UUID(uuidString: $0.recordID) }
+        )
+        let allEvents = fetchScoreEvents(withIDs: pendingEventIDs)
         let eventsByID = Dictionary(uniqueKeysWithValues: allEvents.map { ($0.id, $0) })
 
         // Build batch FIRST to identify which entries can actually be pushed.
@@ -220,13 +225,20 @@ public actor SyncEngine: ModelActor {
             return
         }
 
-        let existingEvents = fetchAllScoreEvents()
+        // Parse all CKRecords up front to scope the local event fetch to affected rounds
+        let dtos = fetched.compactMap { ScoreEventRecord(from: $0) }
+        guard !dtos.isEmpty else {
+            syncState = .idle
+            return
+        }
+
+        let incomingRoundIDs = Set(dtos.map(\.roundID))
+        let existingEvents = fetchScoreEvents(forRoundIDs: incomingRoundIDs)
         let existingIDs = Set(existingEvents.map(\.id))
         var affectedRoundIDs: Set<UUID> = []
         var newlyInsertedEvents: [ScoreEvent] = []
 
-        for ckRecord in fetched {
-            guard let dto = ScoreEventRecord(from: ckRecord) else { continue }
+        for dto in dtos {
             guard !existingIDs.contains(dto.id) else { continue }   // deduplicate
 
             let event = ScoreEvent(
@@ -283,9 +295,13 @@ public actor SyncEngine: ModelActor {
     ///
     /// Pre-fetches existing Discrepancy records to deduplicate (Story 6.1: resolution event guard).
     private func detectConflicts(newEvents: [ScoreEvent], allExisting: [ScoreEvent]) {
+        let affectedRoundIDArray = Array(Set(newEvents.map(\.roundID)))
         let existingDiscrepancies: [Discrepancy]
         do {
-            existingDiscrepancies = try modelContext.fetch(FetchDescriptor<Discrepancy>())
+            let descriptor = FetchDescriptor<Discrepancy>(
+                predicate: #Predicate { affectedRoundIDArray.contains($0.roundID) }
+            )
+            existingDiscrepancies = try modelContext.fetch(descriptor)
         } catch {
             logger.error("SyncEngine: failed to fetch discrepancies — dedup guard bypassed: \(error)")
             return
@@ -345,6 +361,7 @@ public actor SyncEngine: ModelActor {
     /// on macOS test hosts. Bounded in practice: one entry per sync attempt.
     private func fetchAllMetadata() -> [SyncMetadata] {
         do {
+            // swiftlint:disable:next unbounded_fetch_descriptor
             return try modelContext.fetch(FetchDescriptor<SyncMetadata>())
         } catch {
             logger.error("SyncEngine.fetchAllMetadata failed: \(error)")
@@ -352,13 +369,31 @@ public actor SyncEngine: ModelActor {
         }
     }
 
-    /// Fetches all ScoreEvents. Same fetch-all strategy as `fetchAllMetadata()`.
-    /// Bounded in practice by round scope (~1,500 events/round peak).
-    private func fetchAllScoreEvents() -> [ScoreEvent] {
+    /// Fetches ScoreEvents whose IDs are in `ids`. Used by the push pipeline to look up
+    /// only the events referenced by pending SyncMetadata entries.
+    private func fetchScoreEvents(withIDs ids: Set<UUID>) -> [ScoreEvent] {
+        guard !ids.isEmpty else { return [] }
+        let idArray = Array(ids)
+        var descriptor = FetchDescriptor<ScoreEvent>(predicate: #Predicate { idArray.contains($0.id) })
+        descriptor.fetchLimit = idArray.count
         do {
-            return try modelContext.fetch(FetchDescriptor<ScoreEvent>())
+            return try modelContext.fetch(descriptor)
         } catch {
-            logger.error("SyncEngine.fetchAllScoreEvents failed: \(error)")
+            logger.error("SyncEngine.fetchScoreEvents(withIDs:) failed: \(error)")
+            return []
+        }
+    }
+
+    /// Fetches ScoreEvents scoped to the given round IDs. Used by the pull pipeline and
+    /// conflict detection to avoid full-table scans on the event-sourced table.
+    private func fetchScoreEvents(forRoundIDs roundIDs: Set<UUID>) -> [ScoreEvent] {
+        guard !roundIDs.isEmpty else { return [] }
+        let roundIDArray = Array(roundIDs)
+        let descriptor = FetchDescriptor<ScoreEvent>(predicate: #Predicate { roundIDArray.contains($0.roundID) })
+        do {
+            return try modelContext.fetch(descriptor)
+        } catch {
+            logger.error("SyncEngine.fetchScoreEvents(forRoundIDs:) failed: \(error)")
             return []
         }
     }


### PR DESCRIPTION
## Summary

Completes all four P0 items from the technical debt roadmap (pre-TestFlight stabilization).

### P0-1 — Unbounded `FetchDescriptor` in `SyncEngine`
- `pushPending()`: scoped `ScoreEvent` fetch to only the IDs referenced by pending `SyncMetadata` entries (was fetching the entire event-sourced table)
- `pullRecords()`: parse all incoming `CKRecord` DTOs first, then fetch local events by round ID — eliminates the full-table scan on pull
- `detectConflicts()`: added `#Predicate` to scope `Discrepancy` fetch to affected round IDs only
- Removed `fetchAllScoreEvents()`; added `fetchScoreEvents(withIDs:)` and `fetchScoreEvents(forRoundIDs:)`

### P0-2 — Silent `try?` on fetch/IO converted to `do/catch`
- `HistoryListViewModel`: course name fetch now logs and falls back gracefully
- `AppServices.resolveLocalPlayerID`: fetch error is now logged via `os.log`
- `HyzerApp.deleteStore`: justification comment added to `try? fm.removeItem`
- `VoiceOverlayViewModel`, `WatchVoiceViewModel`, `VoiceOverlayView`: justification comments added to all `try? Task.sleep` sites (CancellationError is the normal timer-cancel signal)

### P0-3 — SwiftLint custom rule
- Added `unbounded_fetch_descriptor` warning rule — fires on bare `FetchDescriptor<Foo>()` (no predicate, no fetchLimit)
- Suppressed at the one intentional fetch-all site (`fetchAllMetadata`) with `// swiftlint:disable:next` and existing doc-comment justification

### P0-4 — MetricKit observability
- New `MetricKitObserver` singleton registered at app startup (`HyzerApp.init()`)
- Implements `MXMetricManagerSubscriber` to receive daily metric payloads and post-crash diagnostics
- Logs via `os.log` (category `MetricKit`) and writes JSON payloads to `applicationSupportDirectory/MetricKitLogs/` for offline inspection
- No external dependencies — Apple-native, zero SPM overhead

## Test plan

- [ ] `swift test --package-path HyzerKit` — all 269 tests pass ✅
- [ ] Build app in Xcode against iPhone 17 with Watch simulator — no new warnings
- [ ] Verify `unbounded_fetch_descriptor` lint rule fires: add `FetchDescriptor<Player>()` to a scratch file, confirm Xcode shows a warning, then revert
- [ ] Force a debug crash (e.g. `fatalError("test")`) and relaunch — `MetricKitLogs/` directory should appear in app sandbox on next day's delivery (MetricKit delivers diagnostics on the subsequent launch after a crash)
- [ ] Filter Console.app for subsystem `com.shotcowboystyle.hyzerapp` + category `MetricKit` to confirm registration log on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)