### PR TITLE
feat(p1): stabilization sprint — debt reduction across five areas

### DIFF
--- a/HyzerApp.xcodeproj/project.pbxproj
+++ b/HyzerApp.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		93BDDE9BB3DD4F18A7A26E3F /* HyzerKit in Frameworks */ = {isa = PBXBuildFile; productRef = FBF7E3B49360BEFE78202833 /* HyzerKit */; };
 		953A5AFD53D6DB75925EF04B /* DiscrepancyResolveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 186E9E3D3F028244D0C5A241 /* DiscrepancyResolveTests.swift */; };
 		96AFB711CE6C6EC4DF5CE576 /* HyzerWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 1AFA4C5EA37270895D500678 /* HyzerWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		98858E89E1915B90C68829CB /* ShareSheetRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB2B4647E81F997607BBDE3 /* ShareSheetRepresentable.swift */; };
 		9A959DB668F32D68C80D7E24 /* DiscrepancyLoadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7D740D79452CC43CCAA46F /* DiscrepancyLoadTests.swift */; };
 		9DEF4DF4CD1156899DCAD968 /* TestPolling.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4139B302C98F9C9D8B834E7 /* TestPolling.swift */; };
 		A42D386C8B0A344A48653392 /* LiveICloudIdentityProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F4A3FDA72AE73321E44E1B /* LiveICloudIdentityProvider.swift */; };
@@ -116,6 +117,7 @@
 		07389BA2B2E9434AE923CC28 /* WatchStaleIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchStaleIndicatorView.swift; sourceTree = "<group>"; };
 		07943A8909080D9EEB547B64 /* HyzerKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = HyzerKit; path = HyzerKit; sourceTree = SOURCE_ROOT; };
 		0CB3171CF658AC6851293F50 /* VoiceRecognitionServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecognitionServiceProtocol.swift; sourceTree = "<group>"; };
+		0DB2B4647E81F997607BBDE3 /* ShareSheetRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheetRepresentable.swift; sourceTree = "<group>"; };
 		0F654A8DF69B0F48A4399DA2 /* RoundSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundSetupViewModel.swift; sourceTree = "<group>"; };
 		186E9E3D3F028244D0C5A241 /* DiscrepancyResolveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscrepancyResolveTests.swift; sourceTree = "<group>"; };
 		1AFA4C5EA37270895D500678 /* HyzerWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HyzerWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -288,6 +290,7 @@
 		8FC692C15A07F650EB7E475A /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				0DB2B4647E81F997607BBDE3 /* ShareSheetRepresentable.swift */,
 				3D25A260E0DBDD3FFD58E9A3 /* SyncIndicatorView.swift */,
 			);
 			path = Components;
@@ -713,6 +716,7 @@
 				6D665492C05385E1FB50E3B0 /* ScoreInputView.swift in Sources */,
 				079960697F1DB732A0FE5870 /* ScorecardContainerView.swift in Sources */,
 				264848715C0438CE283A1429 /* ScorecardViewModel.swift in Sources */,
+				98858E89E1915B90C68829CB /* ShareSheetRepresentable.swift in Sources */,
 				64457CFB0B3C54CCACB441C1 /* SyncIndicatorView.swift in Sources */,
 				145858141B65FCC7F119CC25 /* VoiceOverlayView.swift in Sources */,
 				5D8E4A77A4DDD95955B5F8D7 /* VoiceOverlayViewModel.swift in Sources */,

--- a/HyzerApp/App/AppServices.swift
+++ b/HyzerApp/App/AppServices.swift
@@ -51,7 +51,8 @@ final class AppServices {
         self.syncScheduler = SyncScheduler(
             syncEngine: syncEngine,
             cloudKitClient: cloudKitClient,
-            networkMonitor: networkMonitor
+            networkMonitor: networkMonitor,
+            userDefaults: UserDefaults.standard
         )
         let deviceID = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
         let scoring = ScoringService(modelContext: modelContainer.mainContext, deviceID: deviceID)

--- a/HyzerApp/Views/Components/ShareSheetRepresentable.swift
+++ b/HyzerApp/Views/Components/ShareSheetRepresentable.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+/// Wraps `UIActivityViewController` for sharing items from SwiftUI.
+struct ShareSheetRepresentable: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/HyzerApp/Views/History/HistoryRoundDetailView.swift
+++ b/HyzerApp/Views/History/HistoryRoundDetailView.swift
@@ -228,14 +228,3 @@ private struct HistoryPlayerRow: View {
     }
 }
 
-// MARK: - ShareSheetRepresentable
-
-private struct ShareSheetRepresentable: UIViewControllerRepresentable {
-    let items: [Any]
-
-    func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(activityItems: items, applicationActivities: nil)
-    }
-
-    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
-}

--- a/HyzerApp/Views/Scoring/RoundSummaryView.swift
+++ b/HyzerApp/Views/Scoring/RoundSummaryView.swift
@@ -44,10 +44,7 @@ struct RoundSummaryView: View {
         }
         .sheet(isPresented: $isShareSheetPresented) {
             if let image = shareImage {
-                ShareSheet(items: [
-                    image,
-                    shareText
-                ])
+                ShareSheetRepresentable(items: [image, shareText])
             }
         }
         .accessibilityElement(children: .contain)
@@ -190,18 +187,6 @@ private struct PlayerSummaryRow: View {
         default: return "\(position)"
         }
     }
-}
-
-// MARK: - ShareSheet
-
-private struct ShareSheet: UIViewControllerRepresentable {
-    let items: [Any]
-
-    func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(activityItems: items, applicationActivities: nil)
-    }
-
-    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }
 
 // MARK: - SummaryCardSnapshotView

--- a/HyzerApp/Views/Scoring/ScorecardContainerView.swift
+++ b/HyzerApp/Views/Scoring/ScorecardContainerView.swift
@@ -144,31 +144,26 @@ struct ScorecardContainerView: View {
     @ViewBuilder
     private var scoringContent: some View {
         ZStack(alignment: .top) {
-            TabView(selection: $currentHole) {
-                ForEach(1...max(1, round.holeCount), id: \.self) { holeNumber in
-                    HoleCardView(
+            ScorecardHoleCardStack(
+                round: round,
+                holeCount: round.holeCount,
+                courseHoles: courseHoles,
+                courseName: courseName,
+                scorecardPlayers: scorecardPlayers,
+                roundScoreEvents: roundScoreEvents,
+                currentHole: $currentHole,
+                onScore: { playerID, holeNumber, strokeCount in
+                    enterScore(playerID: playerID, holeNumber: holeNumber, strokeCount: strokeCount)
+                },
+                onCorrection: { playerID, previousEventID, holeNumber, strokeCount in
+                    correctScore(
+                        playerID: playerID,
+                        previousEventID: previousEventID,
                         holeNumber: holeNumber,
-                        par: par(forHole: holeNumber),
-                        courseName: courseName,
-                        players: scorecardPlayers,
-                        scores: roundScoreEvents.filter { $0.holeNumber == holeNumber },
-                        isRoundFinished: round.isFinished,
-                        onScore: { playerID, strokeCount in
-                            enterScore(playerID: playerID, holeNumber: holeNumber, strokeCount: strokeCount)
-                        },
-                        onCorrection: { playerID, previousEventID, strokeCount in
-                            correctScore(
-                                playerID: playerID,
-                                previousEventID: previousEventID,
-                                holeNumber: holeNumber,
-                                strokeCount: strokeCount
-                            )
-                        }
+                        strokeCount: strokeCount
                     )
-                    .tag(holeNumber)
                 }
-            }
-            .tabViewStyle(.page(indexDisplayMode: .automatic))
+            )
 
             leaderboardPillContent
         }
@@ -401,16 +396,11 @@ struct ScorecardContainerView: View {
     @ViewBuilder
     private var voiceOverlayContent: some View {
         if let voiceVM = voiceOverlayViewModel {
-            let transition: AnyTransition = reduceMotion
-                ? .opacity
-                : .move(edge: .bottom).combined(with: .opacity)
-            VStack {
-                Spacer()
-                VoiceOverlayView(viewModel: voiceVM, par: par(forHole: currentHole))
-                    .transition(transition)
-                    .padding(.bottom, SpacingTokens.lg)
-            }
-            .ignoresSafeArea(edges: .bottom)
+            ScorecardVoiceOverlay(
+                voiceVM: voiceVM,
+                par: par(forHole: currentHole),
+                reduceMotion: reduceMotion
+            )
         }
     }
 
@@ -478,5 +468,66 @@ struct ScorecardContainerView: View {
             get: { lifecycleError != nil },
             set: { if !$0 { lifecycleError = nil } }
         )
+    }
+}
+
+// MARK: - ScorecardHoleCardStack
+
+/// Paged `TabView` of `HoleCardView`s — one card per hole in the round.
+private struct ScorecardHoleCardStack: View {
+    let round: Round
+    let holeCount: Int
+    let courseHoles: [Hole]
+    let courseName: String
+    let scorecardPlayers: [ScorecardPlayer]
+    let roundScoreEvents: [ScoreEvent]
+    @Binding var currentHole: Int
+    let onScore: (String, Int, Int) -> Void
+    let onCorrection: (String, UUID, Int, Int) -> Void
+
+    var body: some View {
+        TabView(selection: $currentHole) {
+            ForEach(1...max(1, holeCount), id: \.self) { holeNumber in
+                let holeParValue = courseHoles.first { $0.number == holeNumber }?.par ?? 3
+                HoleCardView(
+                    holeNumber: holeNumber,
+                    par: holeParValue,
+                    courseName: courseName,
+                    players: scorecardPlayers,
+                    scores: roundScoreEvents.filter { $0.holeNumber == holeNumber },
+                    isRoundFinished: round.isFinished,
+                    onScore: { playerID, strokeCount in
+                        onScore(playerID, holeNumber, strokeCount)
+                    },
+                    onCorrection: { playerID, previousEventID, strokeCount in
+                        onCorrection(playerID, previousEventID, holeNumber, strokeCount)
+                    }
+                )
+                .tag(holeNumber)
+            }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .automatic))
+    }
+}
+
+// MARK: - ScorecardVoiceOverlay
+
+/// Positions and animates `VoiceOverlayView` at the bottom of the scorecard.
+private struct ScorecardVoiceOverlay: View {
+    let voiceVM: VoiceOverlayViewModel
+    let par: Int
+    let reduceMotion: Bool
+
+    var body: some View {
+        let transition: AnyTransition = reduceMotion
+            ? .opacity
+            : .move(edge: .bottom).combined(with: .opacity)
+        VStack {
+            Spacer()
+            VoiceOverlayView(viewModel: voiceVM, par: par)
+                .transition(transition)
+                .padding(.bottom, SpacingTokens.lg)
+        }
+        .ignoresSafeArea(edges: .bottom)
     }
 }

--- a/HyzerApp/Views/Scoring/VoiceOverlayView.swift
+++ b/HyzerApp/Views/Scoring/VoiceOverlayView.swift
@@ -4,8 +4,8 @@ import UIKit
 
 /// Translucent overlay shown after voice recognition completes.
 ///
-/// Displays parsed player-score pairs with a 1.5-second auto-commit progress indicator.
-/// Supports inline correction via an expanded score picker (same `ScoreInputView` pattern).
+/// Delegates to state-specific subviews:
+/// `VoiceListeningView`, `VoiceConfirmingView`, `VoicePartialView`, `VoiceFailedView`.
 /// Presented as a `.overlay()` on `ScorecardContainerView` — not a sheet or fullScreenCover.
 struct VoiceOverlayView: View {
     @Bindable var viewModel: VoiceOverlayViewModel
@@ -13,31 +13,38 @@ struct VoiceOverlayView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    @State private var progress: Double = 0
-    @State private var progressAnimation: Animation? = nil
-    @State private var correctionIndex: Int? = nil
-    @State private var unresolvedIndex: Int? = nil
-
     var body: some View {
         Group {
             switch viewModel.state {
             case .listening:
-                listeningView
+                VoiceListeningView()
             case .confirming(let candidates):
-                confirmingView(candidates: candidates)
+                VoiceConfirmingView(
+                    viewModel: viewModel,
+                    candidates: candidates,
+                    par: par,
+                    reduceMotion: reduceMotion
+                )
             case .partial(let recognized, let unresolved):
-                partialView(recognized: recognized, unresolved: unresolved)
+                VoicePartialView(
+                    viewModel: viewModel,
+                    recognized: recognized,
+                    unresolved: unresolved,
+                    par: par
+                )
             case .failed:
-                failedView
+                VoiceFailedView(viewModel: viewModel)
             default:
                 EmptyView()
             }
         }
     }
+}
 
-    // MARK: - Listening state
+// MARK: - VoiceListeningView
 
-    private var listeningView: some View {
+private struct VoiceListeningView: View {
+    var body: some View {
         VStack(spacing: SpacingTokens.md) {
             Image(systemName: "waveform.circle.fill")
                 .font(TypographyTokens.hero)
@@ -54,10 +61,21 @@ struct VoiceOverlayView: View {
         .clipShape(RoundedRectangle(cornerRadius: SpacingTokens.cornerRadiusCard))
         .padding(.horizontal, SpacingTokens.md)
     }
+}
 
-    // MARK: - Confirming state
+// MARK: - VoiceConfirmingView
 
-    private func confirmingView(candidates: [ScoreCandidate]) -> some View {
+private struct VoiceConfirmingView: View {
+    @Bindable var viewModel: VoiceOverlayViewModel
+    let candidates: [ScoreCandidate]
+    let par: Int
+    let reduceMotion: Bool
+
+    @State private var correctionIndex: Int? = nil
+    @State private var progress: Double = 0
+    @State private var progressAnimation: Animation? = nil
+
+    var body: some View {
         VStack(alignment: .leading, spacing: SpacingTokens.sm) {
             Text("Scores heard")
                 .font(TypographyTokens.caption)
@@ -78,7 +96,7 @@ struct VoiceOverlayView: View {
                     )
                     .padding(.horizontal, SpacingTokens.sm)
                 } else {
-                    playerScoreRow(candidate: candidate, index: index, par: par)
+                    playerScoreRow(candidate: candidate, index: index)
                 }
             }
 
@@ -118,18 +136,14 @@ struct VoiceOverlayView: View {
         .accessibilityAddTraits(.isModal)
     }
 
-    // MARK: - Player row
-
-    private func playerScoreRow(candidate: ScoreCandidate, index: Int, par: Int, interactive: Bool = true) -> some View {
+    private func playerScoreRow(candidate: ScoreCandidate, index: Int) -> some View {
         let rowContent = HStack(alignment: .center, spacing: SpacingTokens.xs) {
             Text(candidate.displayName)
                 .font(TypographyTokens.h2)
                 .foregroundStyle(Color.textPrimary)
                 .lineLimit(1)
-
             DottedLeader()
                 .accessibilityHidden(true)
-
             Text("\(candidate.strokeCount)")
                 .font(TypographyTokens.scoreLarge)
                 .foregroundStyle(Color.scoreColor(strokes: candidate.strokeCount, par: par))
@@ -138,20 +152,12 @@ struct VoiceOverlayView: View {
         .frame(minHeight: 56)
         .padding(.horizontal, SpacingTokens.md)
 
-        return Group {
-            if interactive {
-                Button(action: { correctionIndex = index }) { rowContent }
-                    .buttonStyle(.plain)
-                    .accessibilityHint("Double-tap to correct")
-            } else {
-                rowContent
-            }
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabel(for: candidate, par: par))
+        return Button(action: { correctionIndex = index }) { rowContent }
+            .buttonStyle(.plain)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(accessibilityLabel(for: candidate))
+            .accessibilityHint("Double-tap to correct")
     }
-
-    // MARK: - Progress bar
 
     private var progressBar: some View {
         GeometryReader { geo in
@@ -171,17 +177,62 @@ struct VoiceOverlayView: View {
         .onAppear { startProgress() }
     }
 
-    // MARK: - Partial state
+    private func startProgress() {
+        progressAnimation = nil
+        progress = 0
+        Task { @MainActor in
+            if reduceMotion {
+                progress = 1
+            } else {
+                progressAnimation = .linear(duration: AnimationTokens.autoCommitDuration)
+                progress = 1
+            }
+        }
+    }
 
-    private func partialView(recognized: [ScoreCandidate], unresolved: [UnresolvedCandidate]) -> some View {
+    private func announceScores(_ candidates: [ScoreCandidate]) {
+        let descriptions = candidates.map { "\($0.displayName), \($0.strokeCount)" }.joined(separator: ". ")
+        let announcement = "Voice scores confirmed. \(descriptions). Tap any score to correct."
+        Task { @MainActor in
+            // Delay lets the UI settle before VoiceOver speaks; CancellationError is harmless if Task is deallocated.
+            try? await Task.sleep(for: .milliseconds(500))
+            AccessibilityNotification.Announcement(announcement).post()
+        }
+    }
+
+    private func accessibilityLabel(for candidate: ScoreCandidate) -> String {
+        let delta = candidate.strokeCount - par
+        let parDescription: String
+        switch delta {
+        case ..<(-1): parDescription = "\(abs(delta)) under par"
+        case -1:      parDescription = "birdie"
+        case 0:       parDescription = "par"
+        case 1:       parDescription = "bogey"
+        default:      parDescription = "\(delta) over par"
+        }
+        return "\(candidate.displayName), \(candidate.strokeCount), \(parDescription)"
+    }
+}
+
+// MARK: - VoicePartialView
+
+private struct VoicePartialView: View {
+    @Bindable var viewModel: VoiceOverlayViewModel
+    let recognized: [ScoreCandidate]
+    let unresolved: [UnresolvedCandidate]
+    let par: Int
+
+    @State private var unresolvedIndex: Int? = nil
+
+    var body: some View {
         VStack(alignment: .leading, spacing: SpacingTokens.sm) {
             Text("Partial recognition")
                 .font(TypographyTokens.caption)
                 .foregroundStyle(Color.textSecondary)
                 .padding(.horizontal, SpacingTokens.md)
 
-            ForEach(Array(recognized.enumerated()), id: \.offset) { index, candidate in
-                playerScoreRow(candidate: candidate, index: index, par: par, interactive: false)
+            ForEach(Array(recognized.enumerated()), id: \.offset) { _, candidate in
+                staticPlayerScoreRow(candidate: candidate)
             }
 
             ForEach(Array(unresolved.enumerated()), id: \.offset) { index, entry in
@@ -229,6 +280,25 @@ struct VoiceOverlayView: View {
         .accessibilityAddTraits(.isModal)
     }
 
+    private func staticPlayerScoreRow(candidate: ScoreCandidate) -> some View {
+        HStack(alignment: .center, spacing: SpacingTokens.xs) {
+            Text(candidate.displayName)
+                .font(TypographyTokens.h2)
+                .foregroundStyle(Color.textPrimary)
+                .lineLimit(1)
+            DottedLeader()
+                .accessibilityHidden(true)
+            Text("\(candidate.strokeCount)")
+                .font(TypographyTokens.scoreLarge)
+                .foregroundStyle(Color.scoreColor(strokes: candidate.strokeCount, par: par))
+                .monospacedDigit()
+        }
+        .frame(minHeight: 56)
+        .padding(.horizontal, SpacingTokens.md)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(candidate.displayName), \(candidate.strokeCount)")
+    }
+
     private func unresolvedRow(entry: UnresolvedCandidate, index: Int) -> some View {
         Button(action: { unresolvedIndex = index }) {
             HStack(alignment: .center, spacing: SpacingTokens.xs) {
@@ -236,10 +306,8 @@ struct VoiceOverlayView: View {
                     .font(TypographyTokens.h2)
                     .foregroundStyle(Color.textSecondary)
                     .lineLimit(1)
-
                 DottedLeader()
                     .accessibilityHidden(true)
-
                 Text("?")
                     .font(TypographyTokens.scoreLarge)
                     .foregroundStyle(Color.textSecondary)
@@ -255,9 +323,25 @@ struct VoiceOverlayView: View {
         .accessibilityHint("Double-tap to pick the correct player")
     }
 
-    // MARK: - Failed state
+    private func announcePartial(recognizedCount: Int, unresolvedCount: Int) {
+        let announcement = "Partial recognition. " +
+            "\(recognizedCount) scores confirmed, " +
+            "\(unresolvedCount) unresolved. " +
+            "Tap the highlighted names to select the correct player."
+        Task { @MainActor in
+            // Delay lets the UI settle before VoiceOver speaks; CancellationError is harmless if Task is deallocated.
+            try? await Task.sleep(for: .milliseconds(500))
+            AccessibilityNotification.Announcement(announcement).post()
+        }
+    }
+}
 
-    private var failedView: some View {
+// MARK: - VoiceFailedView
+
+private struct VoiceFailedView: View {
+    @Bindable var viewModel: VoiceOverlayViewModel
+
+    var body: some View {
         VStack(spacing: SpacingTokens.md) {
             Text("Couldn't understand")
                 .font(TypographyTokens.h3)
@@ -302,43 +386,6 @@ struct VoiceOverlayView: View {
         .accessibilityAddTraits(.isModal)
     }
 
-    // MARK: - Helpers
-
-    private func startProgress() {
-        progressAnimation = nil
-        progress = 0
-        Task { @MainActor in
-            if reduceMotion {
-                progress = 1
-            } else {
-                progressAnimation = .linear(duration: AnimationTokens.autoCommitDuration)
-                progress = 1
-            }
-        }
-    }
-
-    private func announceScores(_ candidates: [ScoreCandidate]) {
-        let descriptions = candidates.map { "\($0.displayName), \($0.strokeCount)" }.joined(separator: ". ")
-        let announcement = "Voice scores confirmed. \(descriptions). Tap any score to correct."
-        Task { @MainActor in
-            // Delay lets the UI settle before VoiceOver speaks; CancellationError is harmless if Task is deallocated.
-            try? await Task.sleep(for: .milliseconds(500))
-            AccessibilityNotification.Announcement(announcement).post()
-        }
-    }
-
-    private func announcePartial(recognizedCount: Int, unresolvedCount: Int) {
-        let announcement = "Partial recognition. " +
-            "\(recognizedCount) scores confirmed, " +
-            "\(unresolvedCount) unresolved. " +
-            "Tap the highlighted names to select the correct player."
-        Task { @MainActor in
-            // Delay lets the UI settle before VoiceOver speaks; CancellationError is harmless if Task is deallocated.
-            try? await Task.sleep(for: .milliseconds(500))
-            AccessibilityNotification.Announcement(announcement).post()
-        }
-    }
-
     private func announceFailure() {
         let announcement = "Couldn't understand. Double-tap Try Again to retry, or Cancel to return to scoring."
         Task { @MainActor in
@@ -346,19 +393,6 @@ struct VoiceOverlayView: View {
             try? await Task.sleep(for: .milliseconds(500))
             AccessibilityNotification.Announcement(announcement).post()
         }
-    }
-
-    private func accessibilityLabel(for candidate: ScoreCandidate, par: Int) -> String {
-        let delta = candidate.strokeCount - par
-        let parDescription: String
-        switch delta {
-        case ..<(-1): parDescription = "\(abs(delta)) under par"
-        case -1:      parDescription = "birdie"
-        case 0:       parDescription = "par"
-        case 1:       parDescription = "bogey"
-        default:      parDescription = "\(delta) over par"
-        }
-        return "\(candidate.displayName), \(candidate.strokeCount), \(parDescription)"
     }
 }
 

--- a/HyzerKit/Sources/HyzerKit/Domain/ConflictDetector.swift
+++ b/HyzerKit/Sources/HyzerKit/Domain/ConflictDetector.swift
@@ -8,7 +8,7 @@ import SwiftData
 /// - `.correction` — `supersedesEventID` set, target event has same `deviceID`
 /// - `.silentMerge` — different device, same `strokeCount`, both `supersedesEventID == nil`
 /// - `.discrepancy` — different device with different `strokeCount`, or cross-device supersession
-public enum ConflictResult: Sendable {
+public enum ConflictResult: Sendable, Equatable {
     /// No other event exists for this {player, hole} — first score recorded.
     case noConflict
     /// Same-device correction: `newEvent.supersedesEventID` points to an event from the same device.

--- a/HyzerKit/Sources/HyzerKit/Sync/SyncScheduler.swift
+++ b/HyzerKit/Sources/HyzerKit/Sync/SyncScheduler.swift
@@ -33,7 +33,7 @@ public actor SyncScheduler {
     private let syncEngine: SyncEngine
     private let cloudKitClient: any CloudKitClient
     private let networkMonitor: any NetworkMonitor
-    private let userDefaults: UserDefaults
+    private let userDefaults: any UserDefaultsStorage
 
     /// Active polling task; non-nil while a round is in progress.
     private var pollingTask: Task<Void, Never>?
@@ -50,7 +50,7 @@ public actor SyncScheduler {
         syncEngine: SyncEngine,
         cloudKitClient: any CloudKitClient,
         networkMonitor: any NetworkMonitor,
-        userDefaults: UserDefaults = .standard
+        userDefaults: any UserDefaultsStorage = UserDefaults.standard
     ) {
         self.syncEngine = syncEngine
         self.cloudKitClient = cloudKitClient
@@ -166,7 +166,7 @@ public actor SyncScheduler {
                     to: recordType,
                     predicate: NSPredicate(value: true)
                 )
-                userDefaults.set(subID, forKey: defaultsKey)
+                userDefaults.setString(subID, forKey: defaultsKey)
                 logger.info("SyncScheduler: registered CKSubscription \(subID) for \(recordType)")
             } catch {
                 logger.error("SyncScheduler: failed to subscribe to \(recordType): \(error)")

--- a/HyzerKit/Sources/HyzerKit/Sync/UserDefaultsStorage.swift
+++ b/HyzerKit/Sources/HyzerKit/Sync/UserDefaultsStorage.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Abstracts `UserDefaults` reads/writes used by `SyncScheduler`
+/// so the scheduler can be tested without persistent storage.
+public protocol UserDefaultsStorage: Sendable {
+    func string(forKey defaultName: String) -> String?
+    func setString(_ value: String, forKey defaultName: String)
+}
+
+extension UserDefaults: UserDefaultsStorage {
+    public func setString(_ value: String, forKey defaultName: String) {
+        set(value, forKey: defaultName)
+    }
+}


### PR DESCRIPTION
## Summary

Completes all P1 items from the Epics 1–8 technical debt roadmap (`buzzing-sauteeing-newell.md`).

- **UserDefaultsStorage protocol** — `SyncScheduler` now accepts `any UserDefaultsStorage` instead of a concrete `UserDefaults`, enabling true mock injection in tests without named UserDefaults suites. `AppServices` passes `UserDefaults.standard` explicitly.
- **ConflictResult: Equatable** — trivial one-word addition that eliminates test workarounds requiring switch exhaustion to inspect associated values.
- **ShareSheetRepresentable extracted** — removes the duplicate `private struct ShareSheet` (RoundSummaryView) and `private struct ShareSheetRepresentable` (HistoryRoundDetailView); both now use the shared component at `HyzerApp/Views/Components/ShareSheetRepresentable.swift`.
- **VoiceOverlayView decomposed** — extracted four state-scoped `View` structs: `VoiceListeningView`, `VoiceConfirmingView` (owns `correctionIndex`/`progress` state), `VoicePartialView` (owns `unresolvedIndex` state), `VoiceFailedView`. Main struct becomes a pure ~35-line switch dispatch.
- **ScorecardContainerView decomposed** — extracted `ScorecardHoleCardStack` (the paged TabView with HoleCardViews) and `ScorecardVoiceOverlay` (transition + positioning) as `private struct`s, reducing the main view body complexity.

Items verified complete but not requiring code changes:
- **xcodegen git hooks** — `post-checkout` / `post-merge` hooks already present and correct.
- **Test coverage parity** — `CourseEditorCreateTests`, `CourseEditorDeleteTests`, `CourseEditorEditTests` provide full coverage parity vs the original split file.
- **ColorTokens.border** — no references found in codebase; already clean.
- **ValueCollector duplicates** — single canonical source already exists; no duplicates.
- **Bare Task.sleep in tests** — none found outside `MockCloudKitClient` (acceptable, optional-latency pattern).

## Test plan

- [ ] `swift test --package-path HyzerKit` — 269 tests pass (verified locally)
- [ ] Full Xcode build passes with no new errors (pre-existing `MetricKitObserver` concurrency warning unrelated to this PR)
- [ ] Voice overlay: manually verify Listening → Confirming → Commit flow in simulator
- [ ] Scorecard: verify auto-advance and voice entry still work after subview extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)