### PR TITLE
fix(p1): redact player IDs in logs and rotate MetricKit files

### DIFF
--- a/HyzerApp.xcodeproj/project.pbxproj
+++ b/HyzerApp.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		AFB736F4735547A36BC33DA0 /* VoiceOverlayPartialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE7A42C5BEB81001969149 /* VoiceOverlayPartialTests.swift */; };
 		B3D98F92087F5C9611A47CDB /* HistoryRoundDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBFA94F23F14F7084D8F10F /* HistoryRoundDetailView.swift */; };
 		B483D5DD3EEB6F2933881AE3 /* VoiceOverlayErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226EC5847B621BD211AC83D4 /* VoiceOverlayErrorTests.swift */; };
+		BAA2DB0D06B75266DE809C28 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A49A9D6C97929C49846555A0 /* PrivacyInfo.xcprivacy */; };
 		BB4F7B88144CBDAB1CC7F341 /* DiscrepancyResolutionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A104F8591B7E99E09D839F /* DiscrepancyResolutionView.swift */; };
 		BB9D46C1C270FF43393D5024 /* HistoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F15A3320EA3B193B04FB19E /* HistoryListView.swift */; };
 		BD0CC4EF29D368850F3C554C /* VoiceRecognitionServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB3171CF658AC6851293F50 /* VoiceRecognitionServiceProtocol.swift */; };
@@ -161,6 +162,7 @@
 		9CF27AB5613FDD66774D32B9 /* PhoneConnectivityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneConnectivityService.swift; sourceTree = "<group>"; };
 		A0348F5FC211306493C34EDC /* HyzerApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HyzerApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A11CB2EA23B021251B93ADEE /* LeaderboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardViewModel.swift; sourceTree = "<group>"; };
+		A49A9D6C97929C49846555A0 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AA0179A787B752A224A7B38E /* VoiceOverlayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverlayViewModel.swift; sourceTree = "<group>"; };
 		AFA427C207F29690C81D69DD /* CourseEditorEditTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseEditorEditTests.swift; sourceTree = "<group>"; };
 		B04BA312C596DB4B88277D5D /* RoundSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundSummaryViewModel.swift; sourceTree = "<group>"; };
@@ -362,6 +364,7 @@
 				C2DE096DC71267D6C2C700CD /* HyzerApp.entitlements */,
 				2CC2A9F18AFB9B84DAD30F16 /* HyzerApp.swift */,
 				BC03976642023E145926871B /* Info.plist */,
+				A49A9D6C97929C49846555A0 /* PrivacyInfo.xcprivacy */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -614,6 +617,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5827D9E4DC7FC42B10CF812A /* Assets.xcassets in Resources */,
+				BAA2DB0D06B75266DE809C28 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HyzerApp/App/PrivacyInfo.xcprivacy
+++ b/HyzerApp/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <!-- Used by MetricKitObserver to read file creation dates for log rotation -->
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+        <dict>
+            <!-- Used by SyncScheduler to persist last-sync timestamps -->
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/HyzerApp/Services/MetricKitObserver.swift
+++ b/HyzerApp/Services/MetricKitObserver.swift
@@ -54,12 +54,38 @@ final class MetricKitObserver: NSObject, MXMetricManagerSubscriber {
         let logsDir = dir.appendingPathComponent("MetricKitLogs", isDirectory: true)
         do {
             try FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
+            pruneOldPayloads(in: logsDir, prefix: prefix)
             let timestamp = Int(Date().timeIntervalSince1970)
             let fileURL = logsDir.appendingPathComponent("\(prefix)-\(timestamp).json")
             try data.write(to: fileURL)
             logger.info("MetricKit payload written to \(fileURL.lastPathComponent)")
         } catch {
             logger.error("MetricKit: failed to write payload: \(error)")
+        }
+    }
+
+    /// Removes files older than 7 days and keeps at most 20 per prefix, newest first.
+    private func pruneOldPayloads(in dir: URL, prefix: String) {
+        let cutoff = Date().addingTimeInterval(-7 * 24 * 3_600)
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: [.creationDateKey],
+            options: .skipsHiddenFiles
+        ) else { return }
+
+        let matching = contents
+            .filter { $0.lastPathComponent.hasPrefix(prefix) }
+            .compactMap { url -> (URL, Date)? in
+                let date = (try? url.resourceValues(forKeys: [.creationDateKey]))?.creationDate ?? .distantPast
+                return (url, date)
+            }
+            .sorted { $0.1 > $1.1 } // newest first
+
+        for (index, (url, creationDate)) in matching.enumerated() {
+            if creationDate < cutoff || index >= 20 {
+                try? fm.removeItem(at: url)
+            }
         }
     }
 }

--- a/HyzerKit/Sources/HyzerKit/Sync/SyncEngine.swift
+++ b/HyzerKit/Sources/HyzerKit/Sync/SyncEngine.swift
@@ -320,7 +320,7 @@ public actor SyncEngine: ModelActor {
             case .noConflict, .correction:
                 break
             case .silentMerge:
-                logger.debug("SyncEngine: silent merge for player \(newEvent.playerID) hole \(newEvent.holeNumber)")
+                logger.debug("SyncEngine: silent merge for player \(newEvent.playerID, privacy: .private) hole \(newEvent.holeNumber)")
             case .discrepancy(let existingID, let incomingID):
                 let alreadyExists = existingDiscrepancies.contains {
                     $0.roundID == newEvent.roundID &&
@@ -330,7 +330,7 @@ public actor SyncEngine: ModelActor {
                 guard !alreadyExists else {
                     let pid = newEvent.playerID
                     let hole = newEvent.holeNumber
-                    logger.debug("SyncEngine: discrepancy exists for player \(pid) hole \(hole) — skip")
+                    logger.debug("SyncEngine: discrepancy exists for player \(pid, privacy: .private) hole \(hole) — skip")
                     break
                 }
                 let discrepancy = Discrepancy(
@@ -341,7 +341,7 @@ public actor SyncEngine: ModelActor {
                     eventID2: incomingID
                 )
                 modelContext.insert(discrepancy)
-                logger.info("SyncEngine: discrepancy for player \(newEvent.playerID) hole \(newEvent.holeNumber)")
+                logger.info("SyncEngine: discrepancy for player \(newEvent.playerID, privacy: .private) hole \(newEvent.holeNumber)")
             }
         }
 


### PR DESCRIPTION
## Summary
- **P1-1 (privacy):** Three `Logger` interpolations in `SyncEngine` that emitted `playerID` values (which may be opaque guest UUIDs) into the system log archive are now marked `privacy: .private`. In release builds the OS replaces the value with `<private>` across all log sinks — Console, sysdiagnose bundles, and MetricKit crash attachments.
- **P1-2 (data hygiene):** `MetricKitObserver` now prunes payload files before each write — removes any file older than 7 days and keeps at most 20 per prefix (`metrics` / `diagnostic`). Previously files accumulated without bound and were included in device backups.
- **PrivacyInfo.xcprivacy:** Added `HyzerApp/App/PrivacyInfo.xcprivacy` declaring the two accessed-API categories the app actually uses: file timestamp reads (MetricKit rotation) and UserDefaults access (SyncScheduler sync timestamps). XcodeGen picked it up automatically (4 pbxproj refs).

This is **Group C** of the pre-TestFlight review.

### Changes
- `HyzerKit/Sources/HyzerKit/Sync/SyncEngine.swift` — `privacy: .private` on 3 playerID interpolations
- `HyzerApp/Services/MetricKitObserver.swift` — `pruneOldPayloads(in:prefix:)` runs before each write
- `HyzerApp/App/PrivacyInfo.xcprivacy` (new) — accessed API declarations
- `HyzerApp.xcodeproj/project.pbxproj` — XcodeGen-updated to include PrivacyInfo.xcprivacy

## Test plan
- [x] HyzerKit CLI: `swift test --package-path HyzerKit` — 278/278 passing
- [ ] HyzerApp iOS suite via Xcode GUI (`⌘U`) — no regressions
- [ ] Manual log check: run a round with a guest player, then `xcrun simctl spawn booted log show --predicate 'subsystem == "com.shotcowboystyle.hyzerapp"' --last 5m` — player IDs should appear as `<private>`
- [ ] Xcode archive build — verify no "missing PrivacyInfo.xcprivacy" warning in the build log

🤖 Generated with [Claude Code](https://claude.com/claude-code)