### PR TITLE
feat(p1): stabilization sprint — debt reduction across five areas

### DIFF
--- a/HyzerApp/App/HyzerApp.swift
+++ b/HyzerApp/App/HyzerApp.swift
@@ -29,9 +29,12 @@ struct HyzerApp: App {
             ContentView()
                 .environment(appServices)
                 .modelContainer(appServices.modelContainer)
-                .task { await appServices.resolveICloudIdentity() }
-                .task { await appServices.seedCoursesIfNeeded() }
-                .task { await appServices.startSync() }
+                .task {
+                    // Sequential: identity must resolve before seeds, seeds before sync
+                    await appServices.resolveICloudIdentity()
+                    await appServices.seedCoursesIfNeeded()
+                    await appServices.startSync()
+                }
                 .onChange(of: scenePhase) { _, newPhase in
                     switch newPhase {
                     case .active:

--- a/HyzerApp/ViewModels/CourseEditorViewModel.swift
+++ b/HyzerApp/ViewModels/CourseEditorViewModel.swift
@@ -12,7 +12,7 @@ final class CourseEditorViewModel {
     private(set) var existingCourse: Course?
     var courseName: String = ""
     var holeCount: Int = 18
-    var holePars: [Int] = Array(repeating: 3, count: 18)
+    var holePars: [Int] = Array(repeating: Hole.defaultPar, count: 18)
 
     var canSave: Bool {
         !courseName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -38,7 +38,7 @@ final class CourseEditorViewModel {
         guard count == 9 || count == 18 else { return }
         let old = holePars
         holePars = (0..<count).map { i in
-            i < old.count ? old[i] : 3
+            i < old.count ? old[i] : Hole.defaultPar
         }
         holeCount = count
     }

--- a/HyzerApp/Views/History/HistoryListView.swift
+++ b/HyzerApp/Views/History/HistoryListView.swift
@@ -55,7 +55,7 @@ struct HistoryListView: View {
     private func roundList(vm: HistoryListViewModel) -> some View {
         ScrollView {
             LazyVStack(spacing: SpacingTokens.md) {
-                ForEach(completedRounds) { round in
+                ForEach(completedRounds, id: \.id) { round in
                     NavigationLink {
                         HistoryRoundDetailView(round: round, currentPlayerID: currentPlayerID)
                     } label: {

--- a/HyzerApp/Views/Leaderboard/LeaderboardPillView.swift
+++ b/HyzerApp/Views/Leaderboard/LeaderboardPillView.swift
@@ -20,6 +20,10 @@ struct LeaderboardPillView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    private enum Layout {
+        static let pillHeight: CGFloat = 32
+    }
+
     var body: some View {
         ZStack(alignment: .topTrailing) {
             ScrollViewReader { proxy in
@@ -32,7 +36,7 @@ struct LeaderboardPillView: View {
                     }
                     .padding(.horizontal, SpacingTokens.sm)
                 }
-                .frame(height: 32)
+                .frame(height: Layout.pillHeight)
                 .background(.ultraThinMaterial)
                 .background(Color.backgroundElevated.opacity(0.5))
                 .clipShape(Capsule())

--- a/HyzerApp/Views/Scoring/VoiceOverlayView.swift
+++ b/HyzerApp/Views/Scoring/VoiceOverlayView.swift
@@ -75,6 +75,10 @@ private struct VoiceConfirmingView: View {
     @State private var progress: Double = 0
     @State private var progressAnimation: Animation? = nil
 
+    private enum Layout {
+        static let progressBarHeight: CGFloat = 4
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: SpacingTokens.sm) {
             Text("Scores heard")
@@ -164,14 +168,14 @@ private struct VoiceConfirmingView: View {
             ZStack(alignment: .leading) {
                 Capsule()
                     .fill(Color.backgroundTertiary)
-                    .frame(height: 4)
+                    .frame(height: Layout.progressBarHeight)
                 Capsule()
                     .fill(Color.accentPrimary)
-                    .frame(width: geo.size.width * progress, height: 4)
+                    .frame(width: geo.size.width * progress, height: Layout.progressBarHeight)
                     .animation(progressAnimation, value: progress)
             }
         }
-        .frame(height: 4)
+        .frame(height: Layout.progressBarHeight)
         .padding(.horizontal, SpacingTokens.md)
         .accessibilityHidden(true)
         .onAppear { startProgress() }

--- a/HyzerKit/Sources/HyzerKit/Models/Hole.swift
+++ b/HyzerKit/Sources/HyzerKit/Models/Hole.swift
@@ -7,12 +7,14 @@ import SwiftData
 /// CloudKit requires optional or defaulted properties — all fields have defaults.
 @Model
 public final class Hole {
+    public static let defaultPar: Int = 3
+
     public var id: UUID = UUID()
     public var courseID: UUID = UUID()
     public var number: Int = 1
-    public var par: Int = 3
+    public var par: Int = defaultPar
 
-    public init(courseID: UUID, number: Int, par: Int = 3) {
+    public init(courseID: UUID, number: Int, par: Int = defaultPar) {
         self.courseID = courseID
         self.number = number
         self.par = par

--- a/HyzerKit/Sources/HyzerKit/Sync/SyncEngine.swift
+++ b/HyzerKit/Sources/HyzerKit/Sync/SyncEngine.swift
@@ -361,8 +361,13 @@ public actor SyncEngine: ModelActor {
     /// on macOS test hosts. Bounded in practice: one entry per sync attempt.
     private func fetchAllMetadata() -> [SyncMetadata] {
         do {
-            // swiftlint:disable:next unbounded_fetch_descriptor
-            return try modelContext.fetch(FetchDescriptor<SyncMetadata>())
+            var descriptor = FetchDescriptor<SyncMetadata>()
+            descriptor.fetchLimit = 1000
+            let entries = try modelContext.fetch(descriptor)
+            if entries.count == 1000 {
+                logger.error("SyncEngine.fetchAllMetadata hit fetchLimit — SyncMetadata table may be growing unboundedly")
+            }
+            return entries
         } catch {
             logger.error("SyncEngine.fetchAllMetadata failed: \(error)")
             return []

--- a/HyzerKit/Sources/HyzerKit/Sync/SyncScheduler.swift
+++ b/HyzerKit/Sources/HyzerKit/Sync/SyncScheduler.swift
@@ -75,16 +75,17 @@ public actor SyncScheduler {
     public func startActiveRoundPolling() {
         guard pollingTask == nil else { return }
         logger.info("SyncScheduler: starting active round polling (45s interval)")
-        pollingTask = Task { [weak self] in
+        let engine = syncEngine
+        pollingTask = Task {
             while !Task.isCancelled {
                 do {
                     try await Task.sleep(for: .seconds(45))
                 } catch {
                     break  // Task was cancelled during sleep
                 }
-                guard let self, !Task.isCancelled else { break }
-                await self.syncEngine.pushPending()
-                await self.syncEngine.pullRecords()
+                guard !Task.isCancelled else { break }
+                await engine.pushPending()
+                await engine.pullRecords()
             }
         }
     }

--- a/HyzerKit/Tests/HyzerKitTests/Communication/WatchVoiceViewModelTests.swift
+++ b/HyzerKit/Tests/HyzerKitTests/Communication/WatchVoiceViewModelTests.swift
@@ -205,8 +205,8 @@ struct WatchVoiceViewModelTests {
         let result = WatchVoiceResult(result: .success(candidates), holeNumber: holeNumber, roundID: roundID)
         vm.handleVoiceResult(result)
 
-        // Use deterministic polling — exits as soon as condition is met, with 4s safety budget.
-        let committed = await awaitCondition(timeout: .seconds(4)) {
+        // Use deterministic polling — exits as soon as condition is met, with 8s safety budget.
+        let committed = await awaitCondition(timeout: .seconds(8)) {
             if case .committed = vm.state { return true }
             return false
         }

--- a/HyzerWatch/Views/WatchVoiceOverlayView.swift
+++ b/HyzerWatch/Views/WatchVoiceOverlayView.swift
@@ -138,7 +138,8 @@ struct WatchVoiceOverlayView: View {
                 .font(TypographyTokens.body)
                 .foregroundStyle(Color.scoreOverPar)
             if !transcript.isEmpty {
-                Text(transcript)
+                // Cap to 500 chars — defense against a malformed payload from a stale phone build
+                Text(String(transcript.prefix(500)))
                     .font(TypographyTokens.caption)
                     .foregroundStyle(Color.textSecondary)
                     .lineLimit(2)


### PR DESCRIPTION
## Summary
- **P1-4:** `HistoryListView` `ForEach` now pins identity to `\.id` (domain UUID) — prevents card flicker when CloudKit rewrites a Round's `PersistentIdentifier` on pull.
- **P1-5:** Three concurrent root `.task` modifiers chained into one sequential task: `resolveICloudIdentity → seedCoursesIfNeeded → startSync`. Prevents sync racing ahead of seeds or an unresolved iCloud identity.
- **P2-1:** Hardcoded frame heights extracted to private `Layout` enums: `LeaderboardPillView.pillHeight = 32`, `VoiceConfirmingView.progressBarHeight = 4`.
- **P2-2:** `Hole.defaultPar = 3` is the single source of truth. `CourseEditorViewModel` uses it instead of the scattered literal.
- **P2-3:** `SyncEngine.fetchAllMetadata` gets `fetchLimit = 1000` and an error log if the limit is hit. Removes the `swiftlint:disable` suppression.
- **P2-4:** `SyncScheduler.pollingTask` captures `syncEngine` directly (no `[weak self]`). Cleaner and safe — the scheduler owns the engine.
- **P2-5:** `WatchVoiceOverlayView` clamps incoming transcript to 500 chars before display — defense against malformed watch payloads from a stale phone build.
- **Test fix:** `WatchVoiceViewModelTests` auto-commit budget widened from 4 s → 8 s to resolve a pre-existing flaky timing failure noted in CLAUDE.md.

This is **Group D**, the final group of the pre-TestFlight review.

## Test plan
- [x] HyzerKit CLI: `swift test --package-path HyzerKit` — 278/278 passing
- [ ] HyzerApp iOS suite via Xcode GUI (`⌘U`) — no regressions
- [ ] Manual: start a round, score all holes, confirm auto-advance and leaderboard pill render correctly
- [ ] Manual: history list shows previously completed rounds without flicker on navigate-back

🤖 Generated with [Claude Code](https://claude.com/claude-code)