### PR TITLE
feat(design): sync HyzerKit tokens with Claude Design system

### DIFF
--- a/HyzerKit/Sources/HyzerKit/Design/ColorTokens.swift
+++ b/HyzerKit/Sources/HyzerKit/Design/ColorTokens.swift
@@ -32,6 +32,7 @@ public extension Color {
 
     // Accent
     static let accentPrimary = Color(hex: "#30D5C8")
+    static let accentInk     = Color(hex: "#0A0A0C")  // Text/icon over teal fills
 
     // Score states
     static let scoreUnderPar = Color(hex: "#34C759")  // Birdie / under par
@@ -44,6 +45,12 @@ public extension Color {
 
     // Destructive actions only
     static let destructive = Color(hex: "#FF3B30")
+
+    // Hairlines / Overlays
+    static let hairline      = Color(.sRGB, red: 0.961, green: 0.961, blue: 0.969, opacity: 0.08)
+    static let border        = Color.hairline  // Divider token — same as hairline
+    static let rowBackground = Color(.sRGB, red: 0.039, green: 0.039, blue: 0.047, opacity: 0.50)
+    static let pillGlass     = Color(.sRGB, red: 0.110, green: 0.110, blue: 0.118, opacity: 0.50)
 
     /// 4-tier score colour based on strokes relative to par.
     ///

--- a/HyzerKit/Sources/HyzerKit/Design/SpacingTokens.swift
+++ b/HyzerKit/Sources/HyzerKit/Design/SpacingTokens.swift
@@ -15,6 +15,8 @@ public enum SpacingTokens {
     public static let minimumTouchTarget: CGFloat = 44
     /// Recommended touch target for scoring controls.
     public static let scoringTouchTarget: CGFloat = 52
+    /// Generous touch target for voice tap-to-correct — one-handed, walking pace.
+    public static let voiceTouchTarget: CGFloat = 56
 
     /// Fixed width for position column in Watch leaderboard rows.
     public static let watchPositionColumnWidth: CGFloat = 28
@@ -23,4 +25,6 @@ public enum SpacingTokens {
     public static let cornerRadiusCard: CGFloat = 16
     /// Corner radius for inline elements (score buttons, row backgrounds).
     public static let cornerRadiusInline: CGFloat = 8
+    /// Corner radius for pills and capsule buttons (leaderboard pill, primary CTAs).
+    public static let cornerRadiusPill: CGFloat = 999
 }

--- a/HyzerKit/Sources/HyzerKit/Design/TypographyTokens.swift
+++ b/HyzerKit/Sources/HyzerKit/Design/TypographyTokens.swift
@@ -14,9 +14,9 @@ public enum TypographyTokens {
     public static let h2:      Font = .system(.title2,     design: .rounded, weight: .semibold)
     public static let h3:      Font = .system(.headline,   design: .rounded, weight: .semibold)
     public static let body:    Font = .system(.body,       design: .rounded, weight: .regular)
-    public static let caption: Font = .system(.caption,    design: .rounded, weight: .regular)
+    public static let caption: Font = .system(.footnote,   design: .rounded, weight: .regular)
 
     // SF Mono — for score display
     public static let score:      Font = .system(.title2,  design: .monospaced, weight: .bold)
-    public static let scoreLarge: Font = .system(.title,   design: .monospaced, weight: .bold)
+    public static let scoreLarge: Font = .system(.largeTitle, design: .monospaced, weight: .bold)
 }


### PR DESCRIPTION
## Summary

- **Colors** — 5 new tokens: `accentInk` (text/icon over teal fills), `hairline` (divider), `border` (alias for hairline, fixes the undefined-reference tech debt), `rowBackground` (inset row inside cards), `pillGlass` (leaderboard pill behind `.ultraThinMaterial`)
- **Typography** — `caption` corrected from `.caption` (12pt) → `.footnote` (13pt); `scoreLarge` corrected from `.title` (28pt) → `.largeTitle` (34pt) — aligns both with the 13px/34px values in the Claude Design spec
- **Spacing** — 2 new tokens: `voiceTouchTarget` (56pt, tap-to-correct in voice overlay), `cornerRadiusPill` (999, pills and capsule CTAs)
- **Animation** — no changes needed; all values already matched

Source of truth: `hyzer-design-system/project/colors_and_type.css` (Claude Design export).

## Test plan

- [ ] `swift build --package-path HyzerKit` passes (verified locally — Build complete in 3.46s)
- [ ] Views using `TypographyTokens.caption` render at 13pt (was 12pt) — verify in Simulator
- [ ] Views using `TypographyTokens.scoreLarge` render at 34pt (was 28pt) — check Crown display and voice confirmation overlay
- [ ] `Color.border` compiles without error (previously undefined)
- [ ] No hardcoded colors or sizes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)