### PR TITLE
fix(watch-sync): wire activeRoundID so watch leaderboard updates during a round

### DIFF
--- a/HyzerApp/App/AppServices.swift
+++ b/HyzerApp/App/AppServices.swift
@@ -105,8 +105,10 @@ final class AppServices {
         await syncScheduler.startActiveRoundPolling()
     }
 
-    /// Notifies the scheduler that a round ended — stops periodic polling.
+    /// Notifies the scheduler that a round ended — stops periodic polling and clears
+    /// the Watch-sync round context so stale standings aren't pushed for a finished round.
     func roundDidEnd() async {
+        phoneConnectivityService.activeRoundID = nil
         await syncScheduler.stopActiveRoundPolling()
     }
 

--- a/HyzerApp/Services/PhoneConnectivityService.swift
+++ b/HyzerApp/Services/PhoneConnectivityService.swift
@@ -29,7 +29,10 @@ final class PhoneConnectivityService: WatchConnectivityClient {
     private let delegate: SessionDelegate
     private let logger = Logger(subsystem: "com.shotcowboystyle.hyzerapp", category: "PhoneConnectivity")
 
-    /// The active round ID used when building standings snapshots. Set by `AppServices` when a round starts.
+    /// The active round ID used when building standings snapshots.
+    /// Set by `ScorecardContainerView` when scoring begins; cleared by `AppServices.roundDidEnd()`.
+    /// While `nil`, `sendStandings(engine:)` is a no-op — this gates the Watch leaderboard
+    /// off the empty "Waiting for round" state.
     var activeRoundID: UUID?
     /// Current 1-based hole number used when building standings snapshots. Set by scoring views.
     var activeHole: Int = 1

--- a/HyzerApp/Views/Scoring/ScorecardContainerView.swift
+++ b/HyzerApp/Views/Scoring/ScorecardContainerView.swift
@@ -107,7 +107,13 @@ struct ScorecardContainerView: View {
                 discrepancySheetContent
             }
             .onAppear { initializeViewModels() }
-            .onChange(of: currentHole) { autoAdvanceTask?.cancel() }
+            .onChange(of: currentHole) { _, newHole in
+                autoAdvanceTask?.cancel()
+                appServices.phoneConnectivityService.activeHole = newHole
+                appServices.phoneConnectivityService.activeHolePar = par(forHole: newHole)
+                // Push the new hole context to the Watch even when no score was entered.
+                appServices.phoneConnectivityService.sendStandings(engine: appServices.standingsEngine)
+            }
             .task {
                 guard !round.isFinished else { return }
                 await appServices.roundDidStart()
@@ -214,6 +220,12 @@ struct ScorecardContainerView: View {
 
     private func initializeViewModels() {
         guard viewModel == nil else { return }
+        // Watch-sync context: must be set BEFORE the initial `recompute` below so the
+        // standings-observation loop in `PhoneConnectivityService` builds a snapshot with
+        // a non-nil roundID and pushes it to the Watch.
+        appServices.phoneConnectivityService.activeRoundID = round.id
+        appServices.phoneConnectivityService.activeHole = currentHole
+        appServices.phoneConnectivityService.activeHolePar = par(forHole: currentHole)
         guard let organizer = roundPlayers.first(where: { $0.id.uuidString == round.playerIDs.first }) else {
             viewModel = ScorecardViewModel(
                 scoringService: appServices.scoringService,


### PR DESCRIPTION
## Summary
- `PhoneConnectivityService.activeRoundID` was declared but never assigned, so `sendStandings()` always early-returned and the paired watch stayed stuck on "Waiting for round" for the entire round.
- Set the round/hole/par context on the connectivity service in `ScorecardContainerView.initializeViewModels()` *before* the initial `StandingsEngine.recompute`, keep hole/par in sync on `currentHole` swipe (with a direct `sendStandings` so the watch updates even without a new score), and clear `activeRoundID` in `AppServices.roundDidEnd()` to prevent stale pushes after a round finishes.
- No new unit test: `PhoneConnectivityService` uses `WCSession.default` directly with no injection seam and `WatchCacheManager` writes to an app-group container that's `nil` outside an entitled app bundle — falls under the project's "third-party integration that can't be mocked" testing exception in CLAUDE.md.

## Test plan
- [ ] Pair the `iPhone 17 with Watch` simulator, launch HyzerApp + HyzerWatch.
- [ ] Start a round on the iPhone with at least 2 players.
- [ ] Confirm the watch transitions out of "Waiting for round" and shows the leaderboard once the iPhone enters the scorecard.
- [ ] Enter a score on the iPhone; confirm the watch leaderboard reorders/updates in near real time.
- [ ] Swipe to the next hole on the iPhone *without* entering a score; confirm the watch's hole context (used by `WatchScoringView`'s Crown default) updates.
- [ ] Finish the round on the iPhone; navigate back into another round and confirm the leaderboard repopulates with the new round's data (no stale leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
