### PR TITLE
Epic 15 — pre-launch hardening backlog (10 stories)

### DIFF
--- a/_bmad-output/implementation-artifacts/15-1-aps-environment-production-and-app-store-connect-privacy.md
+++ b/_bmad-output/implementation-artifacts/15-1-aps-environment-production-and-app-store-connect-privacy.md
@@ -1,0 +1,197 @@
+# Story 15.1: APS Environment Production Flip & App Store Connect Privacy Mirror
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the developer preparing to submit hyzer-app for App Store distribution beyond TestFlight,
+I want the production APS environment configured on the App Store-bound entitlements and the App Store Connect Privacy section to mirror the in-bundle `PrivacyInfo.xcprivacy` declarations,
+So that the first App Store submission does not get rejected for an entitlement/manifest mismatch or for an undeclared privacy data type.
+
+## Acceptance Criteria
+
+1. **Given** `HyzerApp/App/HyzerApp.entitlements` is opened, **when** the `aps-environment` key is read, **then** the value is `production` (Story 9.1 deferral; Epic 12 push delivery is now done and the entitlement flip is no longer blocked by missing push infrastructure). The watchOS entitlement file (`HyzerWatch/Resources/HyzerWatch.entitlements`) — if it carries an `aps-environment` key — flips identically. Verified by `plutil -p HyzerApp/App/HyzerApp.entitlements` showing `"aps-environment" => "production"`.
+
+2. **Given** the entitlement flip is committed, **when** a fresh Release archive is produced from the resulting branch via the canonical Story 9.1 command (`xcodebuild -project HyzerApp.xcodeproj -scheme HyzerApp -configuration Release -destination 'generic/platform=iOS' -archivePath build/HyzerApp.xcarchive archive`), **then** the archive succeeds without manual signing prompts and the embedded `HyzerApp.app/HyzerApp.entitlements` (extracted via `codesign -d --entitlements - build/HyzerApp.xcarchive/Products/Applications/HyzerApp.app`) carries `aps-environment = production`.
+
+3. **Given** App Store Connect's App Privacy section is opened for `com.shotcowboystyle.hyzerapp`, **when** the declared data types are compared against `HyzerApp/App/PrivacyInfo.xcprivacy`, **then** the two are intent-identical: `NSPrivacyCollectedDataTypeUserID` is declared as `User ID` (Linked to user, Not used for tracking, purpose `App Functionality`), and `NSPrivacyCollectedDataTypeAudioData` is declared as `Audio Data` (Not Linked to user, Not used for tracking, purpose `App Functionality`). No extra categories, no missing categories (Story 9.2 deferral). Evidence: screenshot of the completed questionnaire saved at `_bmad-output/implementation-artifacts/15-1-evidence/asc-app-privacy.png` (gitignored per the `*-evidence/` glob established in Story 9.3 Task 6.2).
+
+4. **Given** CloudKit Dashboard is opened for container `iCloud.com.shotcowboystyle.hyzerapp`, **when** the schema deployment state is inspected, **then** the Development environment schema has been deployed to Production via the "Deploy Schema Changes" action (Story 9.3 Open-Questions operational flag: "If the schema is not deployed to Production, the testers' rounds will not sync — they will install the app successfully but Epic 4 sync will silently fail."). Evidence: screenshot of the Production environment's record-type list matching Development saved at `_bmad-output/implementation-artifacts/15-1-evidence/cloudkit-production-schema.png`.
+
+5. **Given** the entitlement-flipped Release archive is uploaded to App Store Connect via the same Transporter.app / `xcrun altool` path established in Story 9.3 Task 5.1, **when** App Store Connect processes the build, **then** processing completes without "Missing Compliance" / "Invalid Provisioning Profile" / entitlement-mismatch warnings, and the build appears in the TestFlight Builds list as `Ready to Test` within ~30 minutes. The existing `Friends Beta` test group continues to install the new build successfully (regression check that the production APS flip did not break the TestFlight install path).
+
+6. **Given** the canonical regression suite (`swift test --package-path HyzerKit` and the Story 15.2 simulator gate if available) is re-run after the entitlement flip, **when** the suite completes, **then** the count matches the Story 15.2 reconciled baseline and SwiftLint emits zero warnings — the entitlement flip is a `.entitlements` text edit only, with no Swift-source surface area.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Verify pre-state of `aps-environment`** (AC: 1)
+  - [ ] 1.1 Read `HyzerApp/App/HyzerApp.entitlements`. Confirm the current value of the `aps-environment` key is `development` (as documented in `deferred-work.md` for Story 9.1 deferral). If the value is anything else (`production`, missing, malformed), **STOP and surface to the user** — a prior story may have already flipped it.
+  - [ ] 1.2 Read `HyzerWatch/Resources/HyzerWatch.entitlements`. If an `aps-environment` key exists, confirm its value. If it carries `development`, it MUST be flipped to `production` in Task 2. If the file has no `aps-environment` key, do NOT add one — the watchOS app does not receive direct APNs in this codebase (Watch receives leaderboard updates via `WatchConnectivity`, not APNs — per `CLAUDE.md` "Sync Architecture" section).
+  - [ ] 1.3 Run `git log -p HyzerApp/App/HyzerApp.entitlements | head -100` and confirm the last edit to this file was Story 9.1's initial signing setup. If a later commit touched the file, read the commit message before proceeding.
+
+- [ ] **Task 2: Flip `aps-environment` to `production`** (AC: 1)
+  - [ ] 2.1 Edit `HyzerApp/App/HyzerApp.entitlements`: change `<string>development</string>` to `<string>production</string>` under the `aps-environment` key. The surrounding `<key>aps-environment</key>` line is unchanged. No other keys in the file are touched.
+  - [ ] 2.2 If `HyzerWatch/Resources/HyzerWatch.entitlements` carries an `aps-environment` key (per Task 1.2), apply the same flip. Otherwise skip 2.2.
+  - [ ] 2.3 Verify via `plutil -p HyzerApp/App/HyzerApp.entitlements` that the resulting plist is valid and the key now reads `production`. If `plutil` reports a parse error, the edit malformed the XML — revert and re-edit.
+
+- [ ] **Task 3: Re-produce the Release archive against the flipped entitlements** (AC: 2)
+  - [ ] 3.1 On the branch `feature/15-1-aps-production-and-asc-privacy` (per CLAUDE.md "Git Workflow"), run the canonical Story 9.1 archive command verbatim: `xcodebuild -project HyzerApp.xcodeproj -scheme HyzerApp -configuration Release -destination 'generic/platform=iOS' -archivePath build/HyzerApp.xcarchive archive`. Expect `** ARCHIVE SUCCEEDED **`. If signing prompts appear, surface to the user — Story 9.1 verified zero-prompt archive flow; any prompt is a regression.
+  - [ ] 3.2 Verify the embedded entitlement was flipped end-to-end: `codesign -d --entitlements - build/HyzerApp.xcarchive/Products/Applications/HyzerApp.app 2>&1 | grep -A1 aps-environment` — expected output includes `<string>production</string>`. If it still shows `development`, the Release configuration is pulling from a different entitlements file (`project.yml` is the only authority that XcodeGen respects); re-check `project.yml` entitlements references.
+
+- [ ] **Task 4: Mirror the App Privacy questionnaire in App Store Connect** (AC: 3)
+  - [ ] 4.1 **Manual step (cannot be automated from Claude Code):** Log in to `https://appstoreconnect.apple.com` with the Apple ID for team `S4729REPN5`. Navigate to Apps → `hyzer` (the record created in Story 9.3) → App Privacy.
+  - [ ] 4.2 Confirm the existing questionnaire from Story 9.3 Task 3.5 already matches `HyzerApp/App/PrivacyInfo.xcprivacy`. If the prior story closed correctly, this step is a no-op verification. If discrepancies surface (e.g., a category drift caused by an Apple-side questionnaire schema change post-9.3), reconcile to match the manifest verbatim — `User ID` Linked / non-tracking / AppFunctionality, `Audio Data` Not-Linked / non-tracking / AppFunctionality.
+  - [ ] 4.3 Save a fresh screenshot of the completed questionnaire to `_bmad-output/implementation-artifacts/15-1-evidence/asc-app-privacy.png` (create the directory; `.gitignore` already covers the `*-evidence/` glob).
+
+- [ ] **Task 5: Deploy CloudKit schema to Production** (AC: 4)
+  - [ ] 5.1 **Manual step:** Log in to the CloudKit Dashboard (`https://icloud.developer.apple.com/dashboard/`) for container `iCloud.com.shotcowboystyle.hyzerapp`. Open the Schema tab.
+  - [ ] 5.2 Compare the Development schema (record types: `RoundRecord`, `PlayerRecord`, `CourseRecord`, `DiscrepancyRecord`, `ScoreEventRecord`, `SyncMetadata` per `architecture.md` data layer documentation) against the Production schema. If the two match, deployment is already done — skip 5.3.
+  - [ ] 5.3 If Production is missing record types or fields, click "Deploy Schema Changes" — Apple's one-click promote-Development-to-Production operation. Confirm in the dialog. Wait for the deployment to complete (typically <1 minute; UI shows a green confirmation banner).
+  - [ ] 5.4 Save a screenshot of the Production schema list matching Development to `_bmad-output/implementation-artifacts/15-1-evidence/cloudkit-production-schema.png`.
+
+- [ ] **Task 6: Upload the production-APS archive to App Store Connect for regression check** (AC: 5)
+  - [ ] 6.1 Export the archive from Task 3 to IPA using the Story 9.3 Task 5.1 method (Transporter.app preferred). The `ExportOptions.plist` from Story 9.1 Task 5.3 is reused without modification — `method = app-store-connect` is unchanged by this story.
+  - [ ] 6.2 Upload the IPA. Wait for the App Store Connect processing transition from "Processing" to "Ready to Test" (~30 minutes per Story 9.3 dev notes). If a rejection email arrives, the most likely cause is entitlement-mismatch with the provisioning profile — surface the exact rejection text to the user; do NOT auto-revert.
+  - [ ] 6.3 Once `Ready to Test`, assign the build to the `Friends Beta` Internal Test Group (existing group from Story 9.3 Task 5.4). Notify the user that a new build is live; recommend one tester install to confirm the production-APS flip did not break the install path.
+  - [ ] 6.4 If a tester reports install failure or the build does not install, capture the error verbatim and surface — do NOT patch the entitlement until the failure mode is understood (Apple sometimes lags propagating production-APS provisioning profile updates; a 24-hour wait may resolve transient issues).
+
+- [ ] **Task 7: Regression sweep and story closeout** (AC: 6)
+  - [ ] 7.1 Run `swift test --package-path HyzerKit` and confirm the count equals the Story 15.2 reconciled baseline. The entitlement file is not exercised by any Swift test, so the count must be identical.
+  - [ ] 7.2 If a simulator is available, run the canonical `xcodebuild test ...` and confirm the same count.
+  - [ ] 7.3 Stage and commit: `chore(release): flip aps-environment to production and verify asc privacy mirror`. Commit body should reference Story 9.1 / 9.2 / 9.3 deferrals being closed.
+  - [ ] 7.4 Update `_bmad-output/implementation-artifacts/deferred-work.md`: remove the three resolved bullets (Story 9.1 APS environment, Story 9.2 ASC Privacy mirror, Story 9.3 CloudKit schema operational flag). Leave the remaining Story 9.2 entries (`UIUserInterfaceStyle` pin, Info.plist consolidation) — those are owned by Story 15.5.
+
+## Dev Notes
+
+### Why this story exists
+
+Three pre-existing deferrals from Stories 9.1, 9.2, and 9.3 all share a common gate: they cannot land until Epic 12 (Push Notifications) is in production. Epic 12 closed 2026-05-17 with Stories 12.1–12.3 all `done`. The production-APS flip and its sibling ASC-privacy mirror are now unblocked; this story closes all three deferrals in a single PR.
+
+The CloudKit schema deployment is technically a Story 9.3 operational flag, not a strict acceptance criterion. It is bundled here because (a) it is a single CloudKit Dashboard click, (b) it shares the same "manual operational step on apple.com" pattern as the App Privacy mirror, and (c) if it is forgotten, expanded TestFlight or App Store distribution will surface the issue as "rounds don't sync for new testers" — a low-signal, high-confusion failure mode best avoided.
+
+### Current state — what is already correct (do NOT redo)
+
+- **Story 9.1 produced a working Release archive** with correct signing identity and provisioning profile. Story 15.1 reuses that archive flow verbatim — no `project.yml` changes, no signing changes.
+- **Story 9.2 fully populated `PrivacyInfo.xcprivacy`** with `NSPrivacyCollectedDataTypeUserID` and `NSPrivacyCollectedDataTypeAudioData` declarations matching the App Privacy questionnaire spec. The in-bundle manifest is the source of truth; Task 4 reconciles the App Store Connect questionnaire to match.
+- **Story 9.3 created the App Store Connect record and the `Friends Beta` Internal Test Group.** Both already exist; this story reuses both — no new record, no new group.
+- **Story 9.3 Task 5.2 dev note documents the parking lot:** "If a related warning appears [for `aps-environment = development`], do not patch entitlements in this story even if a related warning appears; that is Epic 12's territory (per Story 9.1 dev notes)." This story is the explicit follow-up to that parking lot.
+- **`build/` is already gitignored.** No new gitignore work needed for the archive output.
+- **The `*-evidence/` glob is already gitignored** (Story 9.3 Task 6.2). Creating `15-1-evidence/` requires only `mkdir` — no additional gitignore edit.
+
+### Architecture compliance
+
+- **CLAUDE.md "No silent `try?`":** This story touches no Swift source. Inapplicable.
+- **CLAUDE.md "Bounded SwiftData queries":** Inapplicable; no SwiftData edits.
+- **CLAUDE.md "Accessibility first":** Inapplicable; no UI.
+- **CLAUDE.md "Design tokens only":** Inapplicable; no UI.
+- **CLAUDE.md "Git Workflow":** Work on `feature/15-1-aps-production-and-asc-privacy`. Conventional Commits: `chore(release): flip aps-environment to production and verify asc privacy mirror`.
+- **Architecture §Constraints (`architecture.md:115`):** "TestFlight distribution, 6 users. No App Store review." This story preserves that constraint for the existing TestFlight scope while preparing for the optional future App Store submission — the flip itself is preparation, not commitment.
+- **Architecture §Infrastructure & Development (`architecture.md:392-398`):** Error reporting is intentionally Xcode Organizer + `os_log` only. Do NOT add crash reporters or analytics SDKs even if App Store Connect's onboarding suggests them.
+
+### Library / framework requirements
+
+- **No new Swift package dependencies.** All work is in `.entitlements` text, App Store Connect web UI, and CloudKit Dashboard web UI.
+- **No new framework imports.** APNs production environment uses the same `aps-environment` entitlement key, just with a different value — no SDK or `import` changes.
+
+### File-structure requirements
+
+```
+HyzerApp/App/HyzerApp.entitlements                                       [EDIT — Task 2.1]
+HyzerWatch/Resources/HyzerWatch.entitlements                             [EDIT — Task 2.2 only if aps-environment exists; otherwise no change]
+_bmad-output/implementation-artifacts/15-1-evidence/asc-app-privacy.png          [LOCAL ONLY — Task 4.3]
+_bmad-output/implementation-artifacts/15-1-evidence/cloudkit-production-schema.png  [LOCAL ONLY — Task 5.4]
+build/HyzerApp.xcarchive, build/Export/HyzerApp.ipa                      [LOCAL ONLY — Task 3, gitignored]
+_bmad-output/implementation-artifacts/deferred-work.md                   [EDIT — Task 7.4, remove resolved bullets]
+```
+
+Files that must NOT appear in the final diff:
+- `project.yml`, `HyzerApp.xcodeproj/project.pbxproj` (no build config / signing changes; only the entitlements file is edited)
+- `HyzerApp/App/Info.plist`, `HyzerApp/App/PrivacyInfo.xcprivacy`, `HyzerWatch/Resources/PrivacyInfo.xcprivacy` (Story 9.2 owns these; App Privacy questionnaire is on apple.com)
+- Any Swift source file
+- Any test file
+- Any tester Apple ID, email, or PII
+
+### Testing requirements
+
+- **No unit-test additions.** Per CLAUDE.md "Bug Fixes Require Tests" — this is not a bug fix; it is an operational entitlement flip. No test target loads or executes the `.entitlements` file.
+- **Automated regression check (AC #6):** `swift test --package-path HyzerKit` after Task 2 — same count as Story 15.2 reconciled baseline. All green.
+- **Simulator regression:** `xcodebuild test ...` if simulator available. If not, defer to a reviewer (consistent with Stories 9.1, 9.2, 9.3, 14.1, 14.2).
+- **Manual verification (ACs #1, #3, #4, #5):** Evidence captured via screenshots in the gitignored evidence directory + Completion Notes confirming the tester install path.
+
+### Previous-story intelligence
+
+**Story 9.1 (Release Build Configuration & Signing — done):**
+- Archive command verbatim. ExportOptions.plist template at `build/ExportOptions.plist` is gitignored; recreate from Story 9.1 Task 5.3 if missing.
+- The 9.1 dev agent confirmed `aps-environment = development` was intentional at archive time and parked the flip to Epic 12. That parking lot is now expiring.
+
+**Story 9.2 (Privacy Manifest, Permission Strings & App Icons — done):**
+- `HyzerApp/App/PrivacyInfo.xcprivacy` is the source of truth for the App Privacy questionnaire. The two MUST match — Apple actively rejects submissions where they diverge as of 2025.
+- Story 9.2 Task 5 explicitly deferred the App Store Connect privacy mirror "before TestFlight submission" — that gate is now Task 4 of this story.
+
+**Story 9.3 (App Store Connect Record, TestFlight Test Group & Border Token Debt — done):**
+- The `Friends Beta` Internal Test Group exists at App Store Connect. Reuse it for the regression-install in Task 6.3.
+- The evidence directory pattern (`_bmad-output/implementation-artifacts/<n>-<m>-evidence/`) is established; `.gitignore` already has the glob.
+- The "Open Questions — pre-answered" pattern for operational stories applies here. Anything that requires a user-decision should be elicited in Task 1 BEFORE work begins; this story has none — both the production flip and the questionnaire mirror are pre-determined by Stories 9.1/9.2 ACs.
+- Story 9.3 dev note flagged: "If the schema is not deployed to Production, the testers' rounds will not sync." This is Task 5 of this story.
+
+**Epic 12 (Push Notifications — done, 2026-05-17):**
+- Stories 12.1, 12.2, 12.3 all closed. The push pipeline is live in `development` APS environment for the `Friends Beta` group. Flipping to `production` does not change the push delivery semantics — Apple routes the build's APS environment to the matching APNs gateway (`api.development.push.apple.com` vs. `api.push.apple.com`) based on the entitlement value.
+
+### Latest tech information (2026-05-16)
+
+- **`aps-environment = production` and TestFlight.** TestFlight builds with `production` APS environment work without restriction — Apple routes pushes through the production APNs gateway and the dev's CloudKit-triggered notifications fire identically.
+- **`aps-environment = development` and App Store submission.** The inverse is the rejection-causing direction — App Store-bound builds with `development` APS are rejected at submission with a clear error message ("Invalid Provisioning Profile" or "Push notification entitlement does not match"). This story removes that rejection cause.
+- **CloudKit schema Production deployment** is an idempotent one-click action in the CloudKit Dashboard — no rollback risk; if rerun on an already-deployed Production schema, the dashboard reports "no changes to deploy."
+- **App Privacy questionnaire** is owned by Apple; field names may drift year-over-year. Substance is fixed: the two data types from `PrivacyInfo.xcprivacy` with the same Linked/Tracking/Purpose triples.
+
+### Open questions — pre-answered at story-creation time
+
+All operational choices in this story are derived from prior stories' ACs or from Apple-side requirements; no user elicitation is needed before work begins. The dev agent proceeds directly.
+
+**Pre-answered:**
+- APS environment value → `production` (per Story 9.1 deferral)
+- App Privacy questionnaire data types → mirror `PrivacyInfo.xcprivacy` verbatim (per Story 9.2 deferral)
+- CloudKit schema deployment → deploy Production to match Development (per Story 9.3 operational flag)
+- Test group for the regression install → existing `Friends Beta` (per Story 9.3)
+- Upload tool → Transporter.app default (per Story 9.3 Task 5.1)
+
+### Project Structure Notes
+
+This story's committed footprint is intentionally tiny — a single XML edit to one or two `.entitlements` files plus a `deferred-work.md` cleanup. The bulk of the work is on apple.com (App Store Connect privacy, CloudKit Dashboard) and is evidenced via gitignored screenshots. Acceptance is documented via screenshots + Completion Notes, not by file diffs.
+
+### References
+
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:48-50` — Story 9.1 APS environment deferral text]
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:43-46` — Story 9.2 ASC privacy mirror + Info.plist consolidation deferrals]
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:211` — Story 9.3 CloudKit Production schema operational flag]
+- [Source: `_bmad-output/implementation-artifacts/9-1-release-build-configuration-and-signing.md` — Archive command, ExportOptions.plist, signing setup]
+- [Source: `_bmad-output/implementation-artifacts/9-2-privacy-manifest-permission-strings-and-app-icons.md` — Privacy manifest declarations]
+- [Source: `_bmad-output/implementation-artifacts/9-3-app-store-connect-record-testflight-test-group-and-border-token-debt.md` — App Store Connect record, Friends Beta group, evidence directory pattern]
+- [Source: `HyzerApp/App/HyzerApp.entitlements:19-20` — current `aps-environment = development` value]
+- [Source: `HyzerApp/App/PrivacyInfo.xcprivacy` — source of truth for App Privacy questionnaire]
+- [Source: `_bmad-output/planning-artifacts/epics-post-mvp.md#Epic-15` — this epic's overview and story listing]
+- [Source: `CLAUDE.md` "Project Status" — current state confirmation]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+<!-- Filled by dev agent during execution -->
+
+### Debug Log References
+
+<!-- Filled by dev agent during execution -->
+
+### Completion Notes List
+
+<!-- Filled by dev agent during execution -->
+
+### File List
+
+<!-- Filled by dev agent during execution -->
+
+### Change Log
+
+<!-- Filled by dev agent during execution -->

--- a/_bmad-output/implementation-artifacts/15-10-centralize-history-service-constants.md
+++ b/_bmad-output/implementation-artifacts/15-10-centralize-history-service-constants.md
@@ -1,0 +1,231 @@
+# Story 15.10: Centralize History-Service Constants (`ScoreEvent.maxEventsPerRound`, `RoundStatus.completed`)
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a future contributor refactoring `PlayerTrendService`, `PersonalBestService`, or `HeadToHeadService`,
+I want the `fetchLimit = maxRounds * 20` magic multiplier promoted to a single named constant `ScoreEvent.maxEventsPerRound = 20` and the string-literal predicate `$0.status == "completed"` replaced with a type-safe symbol (e.g., `RoundStatus.completed.rawValue` or a dedicated enum case),
+So that future tweaks to scoring-event-cap or round-status comparison do not require three-service touch-points and a manual cross-grep.
+
+## Acceptance Criteria
+
+1. **Given** `HyzerKit/Sources/HyzerKit/Models/ScoreEvent.swift` is read, **when** the type is inspected, **then** a new declaration appears: `public static let maxEventsPerRound: Int = 20`. A one-line doc comment above the declaration explains the multiplier's origin (Story 13.x history services; per-round upper bound of strokes + corrections per player, accounting for the worst-case 18-hole round with multiple score corrections plus discrepancy resolution events).
+
+2. **Given** `PlayerTrendService.swift`, `PersonalBestService.swift`, and `HeadToHeadService.swift` are inspected (paths: `HyzerKit/Sources/HyzerKit/Domain/`), **when** every `fetchLimit` initialization referencing `* 20` is grep'd, **then** every match uses `ScoreEvent.maxEventsPerRound` instead of the raw `20` literal. Zero raw `* 20` patterns remain in the three files. Validation: `grep -rn 'maxRounds \* 20\|\* 20' HyzerKit/Sources/HyzerKit/Domain/` returns empty.
+
+3. **Given** the same three service files plus any other call site using the string literal `"completed"` to compare `Round.status` (per Story 13.1 deferred-work line 92), **when** the predicates are inspected, **then** the comparison uses the type-safe form. The exact form depends on `Round.status`' type:
+   - If `Round.status` is a `String` field: introduce `enum RoundStatus: String { case active, completed, … }` in `HyzerKit/Sources/HyzerKit/Models/Round.swift` or `RoundStatus.swift`. Update `Round.status` to use the enum. Update predicates to `$0.status == RoundStatus.completed.rawValue`.
+   - If `Round.status` is an existing enum (`RoundStatus`, `Round.LifecycleState`): the comparison already has a type-safe form. Update the predicates to use it.
+   - If `Round.lifecycleState` is the canonical field (CLAUDE.md mentions `lifecycleState`): use `$0.lifecycleState == .completed` and reconcile the file's apparent dual-naming (`status` vs. `lifecycleState`) — surface to the user before committing.
+
+4. **Given** the canonical test command runs after the refactor, **when** the test count is compared to the Story 15.2 reconciled baseline (post-Stories-15.7, 15.8, 15.9 increments if those merged first), **then** the count is identical — this story is a behavior-preserving refactor with no test additions and no test removals. Existing tests must continue to pass; SwiftLint zero warnings.
+
+5. **Given** a new SwiftData service is added in a future story (e.g., `PersonalStreakService` or `CourseHistoryService`), **when** the dev agent reads the doc comments on `ScoreEvent.maxEventsPerRound` and the type-safe `RoundStatus.completed`, **then** the doc comments are sufficient to discover and reuse the constants. No new magic multipliers or string literals enter the codebase.
+
+6. **Given** the deferred-work bullets specifically about magic multipliers and string-literal predicates (Story 13.1 line 92, Story 13.2 line 19, Story 13.3 lines 7-8) are reviewed, **when** the refactor is complete, **then** those bullets are removed or updated to reflect the new state.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Confirm pre-state and reconcile `status` vs. `lifecycleState`** (AC: 3)
+  - [ ] 1.1 Read `HyzerKit/Sources/HyzerKit/Models/Round.swift`. Find the canonical field name for round state — likely `lifecycleState` (per CLAUDE.md "Data & Persistence" mention) but the deferred-work bullets reference `status`. There may be drift between the model and the predicate strings.
+  - [ ] 1.2 If `status` and `lifecycleState` are different fields, surface to the user — the deferred-work bullets may reference an outdated field name. The dev agent should NOT silently rename either field.
+  - [ ] 1.3 If only one field exists (`lifecycleState` is canonical, `status` was the old name, or vice-versa), use it consistently in Task 3.
+  - [ ] 1.4 Check if `RoundStatus` (or `Round.LifecycleState`) is already an enum. If yes, this AC is partially trivial — only update the predicates. If no, the enum needs to be introduced as a sub-task (see Task 3.2 sub-decision).
+
+- [ ] **Task 2: Add `ScoreEvent.maxEventsPerRound`** (AC: 1)
+  - [ ] 2.1 Edit `HyzerKit/Sources/HyzerKit/Models/ScoreEvent.swift`. Add inside the type declaration (above any instance properties):
+    ```swift
+    /// Upper bound on the number of ScoreEvent rows per Round per Player.
+    ///
+    /// Origin: Story 13.x history services bound `fetchLimit = maxRounds * 20`.
+    /// The multiplier `20` covers the worst-case 18-hole round with several
+    /// score corrections plus discrepancy resolution events (each appending
+    /// a new immutable event per event-sourcing semantics — see
+    /// CLAUDE.md "Data & Persistence" event-sourcing invariant).
+    ///
+    /// Used by `PlayerTrendService`, `PersonalBestService`,
+    /// `HeadToHeadService` to size SwiftData fetch limits. Centralize here
+    /// rather than duplicating the literal across services.
+    public static let maxEventsPerRound: Int = 20
+    ```
+  - [ ] 2.2 Run `swift build --package-path HyzerKit` to verify clean compilation.
+
+- [ ] **Task 3: Refactor the three history services** (AC: 2, 3)
+  - [ ] 3.1 Edit `HyzerKit/Sources/HyzerKit/Domain/PlayerTrendService.swift`:
+    - Find every `* 20` literal. Replace with `* ScoreEvent.maxEventsPerRound`.
+    - Find every `$0.status == "completed"` predicate (per Story 13.1 deferred-work line 92). Replace with the type-safe form from Task 1.
+    - Reading: `fetchLimit = maxRounds * 20` → `fetchLimit = maxRounds * ScoreEvent.maxEventsPerRound`.
+    - Predicate: `#Predicate { $0.status == "completed" }` → `#Predicate { $0.lifecycleState == .completed }` (or whatever the type-safe form is — verify with Task 1).
+  - [ ] 3.2 Edit `HyzerKit/Sources/HyzerKit/Domain/PersonalBestService.swift` — same pattern.
+  - [ ] 3.3 Edit `HyzerKit/Sources/HyzerKit/Domain/HeadToHeadService.swift` — same pattern.
+  - [ ] 3.4 If Task 1 revealed `RoundStatus` is NOT an enum and needs to be introduced, this is the moment. Add to `HyzerKit/Sources/HyzerKit/Models/Round.swift` or a new `RoundStatus.swift`:
+    ```swift
+    public enum RoundStatus: String, Codable, Sendable, CaseIterable {
+        case active
+        case completed
+        case abandoned  // include any other statuses currently used
+    }
+    ```
+    The `rawValue: String` conformance preserves backward compatibility with CloudKit (which stores the string). Existing `Round` instances with `status: String` field migrate via SwiftData property type change — verify Swift Data tolerates this without an explicit migration. CLAUDE.md "Data & Persistence" mentions CloudKit requires all properties to be optional/defaulted; the enum-with-rawValue-String form is compatible.
+
+- [ ] **Task 4: Verify no other call sites slipped** (AC: 2, 5)
+  - [ ] 4.1 Run `grep -rn 'maxRounds \* 20\|fetchLimit.*\* 20\|status == "completed"\|\.status == "completed"' HyzerKit HyzerApp HyzerWatch`. Expected: zero matches after Task 3 completes. Surface any remaining match to the user — it indicates a service or test file the dev missed.
+  - [ ] 4.2 Run `grep -rn 'ScoreEvent\.maxEventsPerRound\|RoundStatus\.completed' HyzerKit HyzerApp HyzerWatch`. Expected: 3+ matches in services (Task 3) and possibly any test files that constructed fixtures using the literal.
+
+- [ ] **Task 5: Run the full regression** (AC: 4)
+  - [ ] 5.1 Run `swift test --package-path HyzerKit`. Expect same count as Story 15.2 reconciled baseline (modulo any additions from Stories 15.7, 15.8, 15.9 if those merged first). All green.
+  - [ ] 5.2 Run `xcodebuild test ...` if simulator available — same count and green.
+  - [ ] 5.3 SwiftLint zero warnings. The refactor introduces new declarations and modifies expressions, but all changes are within line-length and function-body limits.
+
+- [ ] **Task 6: Update deferred-work and close** (AC: 6)
+  - [ ] 6.1 Edit `_bmad-output/implementation-artifacts/deferred-work.md`. Remove or update the following bullets:
+    - Line 7 (Story 13.3: SwiftData `#Predicate` IN-clause limits) — only the magic-multiplier sub-concern is closed by this story; the IN-clause concern itself remains open as a separate item. Update the bullet to remove the multiplier mention but keep the IN-clause concern.
+    - Line 8 (Story 13.3: `fetchLimit = maxRounds * 20` magic multiplier) — REMOVED entirely (closed by 15.10).
+    - Line 19 (Story 13.2: `fetchLimit = maxRounds * 20` multiplier under-bounds for multi-course users) — only the magic-number aspect is closed; the under-bounds concern remains open. Update the bullet to remove the literal `20` mention; keep the concern that the multiplier itself may be wrong.
+    - Line 92 (Story 13.1: `$0.status == "completed"` string literal) — REMOVED entirely (closed by 15.10).
+  - [ ] 6.2 Stage and commit: `refactor(services): centralize maxEventsPerRound and RoundStatus.completed constants (Story 15.10)`.
+  - [ ] 6.3 Update `_bmad-output/implementation-artifacts/sprint-status.yaml` — Story 15.10 → `done`.
+
+## Dev Notes
+
+### Why this story exists
+
+Three history services duplicate two patterns:
+1. **`fetchLimit = maxRounds * 20`** — the literal `20` appears verbatim in `PlayerTrendService`, `PersonalBestService`, `HeadToHeadService` (Story 13.1, 13.2, 13.3 deferred-work entries). Tuning the multiplier (e.g., to support discrepancy-heavy rounds with more corrections) currently requires touching all three files and manually grep-checking.
+2. **`$0.status == "completed"`** — string literal predicate (Story 13.1 deferred-work line 92). Identified as "codebase-wide pattern; not story-specific. Would benefit from a type-safe wrapper across all `Round.status` comparisons."
+
+Both are obvious refactor targets but were deferred individually across three stories. Story 15.10 closes both threads in one PR.
+
+The story is behavior-preserving: same fetch sizes, same predicate semantics. The intent is to centralize so future refactors are one-touch instead of three-touch.
+
+### Current state — what is already correct (do NOT redo)
+
+- **The three services are functionally correct** — Stories 13.1, 13.2, 13.3 closed with green tests. This story does NOT change the multiplier value or the predicate semantics.
+- **`fetchLimit` is the correct boundedness mechanism** per CLAUDE.md "Bounded SwiftData queries". This story is centralizing the magic number, not removing the boundedness.
+- **CloudKit synchronization tolerates `Round.status` as a `String`** (per CLAUDE.md "Data & Persistence" "CloudKit models must have all properties optional/defaulted"). If Task 3.4 introduces `RoundStatus` as `enum: String`, the rawValue stays a String — backward-compatible.
+- **Existing tests cover the services' correctness.** The refactor must preserve all existing test pass/fail status (AC #4).
+
+### What this story changes
+
+| Change | File | Notes |
+|---|---|---|
+| Add maxEventsPerRound | `HyzerKit/Sources/HyzerKit/Models/ScoreEvent.swift` | NEW static constant |
+| Possibly introduce RoundStatus enum | `HyzerKit/Sources/HyzerKit/Models/Round.swift` or new `RoundStatus.swift` | Only if currently a String field |
+| Replace literal 20 | `PlayerTrendService.swift`, `PersonalBestService.swift`, `HeadToHeadService.swift` | Use `ScoreEvent.maxEventsPerRound` |
+| Replace string predicate | Same 3 files | Use `RoundStatus.completed.rawValue` or `.completed` per Task 1 |
+| Deferred-work cleanup | `_bmad-output/implementation-artifacts/deferred-work.md` | Remove/update 4 bullets |
+| Sprint state | `_bmad-output/implementation-artifacts/sprint-status.yaml` | 15.10 → done |
+
+### What this story must NOT touch
+
+- **No multiplier-value changes.** `20` stays `20`. If the multiplier is wrong (Story 13.2 line 19 concern), that is a SEPARATE story.
+- **No predicate-semantics changes.** The set of "completed" rounds returned must be unchanged.
+- **No service method signature changes.** Public APIs stay identical.
+- **No test additions or removals.** Existing tests cover the behavior; the refactor must not change which tests pass.
+- **No CloudKit-side schema changes.** If `RoundStatus` becomes an enum, the rawValue is still `String` — CloudKit format unchanged.
+
+### Architecture compliance
+
+- **CLAUDE.md "Bounded SwiftData queries":** Reaffirmed. The `fetchLimit` is now expressed via a named constant.
+- **CLAUDE.md "No silent `try?`":** Inapplicable — refactor doesn't add or remove `try?` patterns.
+- **CLAUDE.md "Design tokens only":** Inapplicable — no UI.
+- **CLAUDE.md "Accessibility first":** Inapplicable — no UI.
+- **CLAUDE.md "Git Workflow":** Branch `feature/15-10-centralize-history-constants`. Conventional commit `refactor(services): centralize maxEventsPerRound and RoundStatus.completed constants`.
+- **Architecture §Data & Persistence:** Event-sourcing invariant preserved — `ScoreEvent.maxEventsPerRound` documents the upper bound but does not enforce it; enforcement is at fetch time via `fetchLimit`.
+
+### Library / framework requirements
+
+- **No new dependencies.** Pure refactor.
+
+### File-structure requirements
+
+```
+HyzerKit/Sources/HyzerKit/Models/ScoreEvent.swift                                        [EDIT — Task 2.1]
+HyzerKit/Sources/HyzerKit/Models/Round.swift                                             [EDIT — Task 3.4 only if RoundStatus enum is introduced]
+HyzerKit/Sources/HyzerKit/Models/RoundStatus.swift                                       [NEW — alternative location for Task 3.4]
+HyzerKit/Sources/HyzerKit/Domain/PlayerTrendService.swift                                [EDIT — Task 3.1]
+HyzerKit/Sources/HyzerKit/Domain/PersonalBestService.swift                               [EDIT — Task 3.2]
+HyzerKit/Sources/HyzerKit/Domain/HeadToHeadService.swift                                 [EDIT — Task 3.3]
+_bmad-output/implementation-artifacts/deferred-work.md                                   [EDIT — Task 6.1]
+_bmad-output/implementation-artifacts/sprint-status.yaml                                 [EDIT — Task 6.3]
+```
+
+Files that must NOT appear in the diff: any test file (existing tests must pass without modification), any HyzerApp view, any HyzerWatch file, any CloudKit DTO files.
+
+### Testing requirements
+
+- **No new tests.** Existing tests fully cover service behavior; the refactor must preserve their outcomes (AC #4).
+- **Regression check:** Test count unchanged. All green. SwiftLint zero warnings.
+
+### Previous-story intelligence
+
+**Story 13.1 deferred-work (line 92):**
+> `$0.status == "completed"` string literal in `PlayerTrendService` predicate (line 77) rather than `RoundStatus.completed` constant — pattern used codebase-wide; not story-specific. Would benefit from a type-safe wrapper across all `Round.status` comparisons.
+
+Story 15.10 implements that type-safe wrapper.
+
+**Story 13.2 deferred-work (line 19):**
+> `fetchLimit = maxRounds * 20` magic multiplier in `HeadToHeadService.computeRecord` / `findOpponentCandidates` — pre-existing PlayerTrendService/PersonalBestService pattern. Promote to a single shared, documented constant (e.g., `ScoreEvent.maxEventsPerRound = 20`).
+
+Story 15.10 implements that promotion.
+
+**Story 13.3 deferred-work (line 8):** Same pattern, referencing the same multiplier.
+
+**Story 13.x ACs (PlayerTrend, PersonalBest, HeadToHead):** All three require explicit `fetchLimit` per CLAUDE.md "Bounded queries". The refactor must NOT remove or weaken the fetchLimit — only replace the literal with the named constant.
+
+### Latest tech information (2026-05-18)
+
+- **Swift Data `#Predicate` with enum comparison:** Works for `String`-backed enums; the predicate compiler can translate `==` against an enum case to the underlying string. Verify with a build after Task 3.
+- **Swift Data property type changes:** Changing `Round.status: String` to `Round.status: RoundStatus` (where RoundStatus is `enum: String`) may or may not require an explicit migration step. Swift Data 2024+ versions tolerate this for `String`-backed enums; older versions may need explicit migration. Verify with a clean build + simulator run.
+
+### Open questions — pre-answered
+
+**Pre-answered:**
+- Constant name → `ScoreEvent.maxEventsPerRound` (per Story 13.2 deferred-work line 19 explicit naming suggestion)
+- Constant value → `20` (preserve current behavior)
+- Type-safe predicate target → `RoundStatus.completed` enum case (introduce enum if not present)
+- Refactor scope → only the three named services + their string-literal predicate sites
+
+**Still requires elicitation (Task 1.2):** If `status` and `lifecycleState` are different fields, surface the field-naming ambiguity to the user before committing.
+
+### Project Structure Notes
+
+The committed diff is small but touches multiple files: one new constant declaration, possibly one new enum, ~10 line-touches across the three services. Logical complexity is low; the value is in the future when a new service is added and the dev agent finds the named constants instead of repeating the magic literals.
+
+### References
+
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:7-8` — Story 13.3 IN-clause limits + magic multiplier]
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:19` — Story 13.2 magic multiplier under-bounds concern]
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:92` — Story 13.1 string-literal predicate concern]
+- [Source: `HyzerKit/Sources/HyzerKit/Models/ScoreEvent.swift` — destination for new constant]
+- [Source: `HyzerKit/Sources/HyzerKit/Models/Round.swift` — destination for RoundStatus enum]
+- [Source: `HyzerKit/Sources/HyzerKit/Domain/PlayerTrendService.swift` — call site]
+- [Source: `HyzerKit/Sources/HyzerKit/Domain/PersonalBestService.swift` — call site]
+- [Source: `HyzerKit/Sources/HyzerKit/Domain/HeadToHeadService.swift` — call site]
+- [Source: `CLAUDE.md` "Bounded queries", "Data & Persistence" — relevant policies]
+- [Source: `_bmad-output/planning-artifacts/epics-post-mvp.md#Story-15.10` — this story's epic-level scope]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+<!-- Filled by dev agent during execution -->
+
+### Debug Log References
+
+<!-- Filled by dev agent during execution -->
+
+### Completion Notes List
+
+<!-- Filled by dev agent during execution -->
+
+### File List
+
+<!-- Filled by dev agent during execution -->
+
+### Change Log
+
+<!-- Filled by dev agent during execution -->

--- a/_bmad-output/implementation-artifacts/15-2-canonical-test-baseline-pre-flight-validation.md
+++ b/_bmad-output/implementation-artifacts/15-2-canonical-test-baseline-pre-flight-validation.md
@@ -1,0 +1,190 @@
+# Story 15.2: Canonical 407-Test Baseline Pre-Flight Validation on Simulator
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the developer about to upload a TestFlight build,
+I want a documented green run of the canonical `xcodebuild test` command against the test-count baseline on the `iPhone 17 with Watch` simulator, plus a single authoritative reconciliation of the three divergent test-count figures floating across CLAUDE.md, Story 9.3, and Story 14.2,
+So that no regression slips into TestFlight from a series of sim-unavailable dev-agent runs that deferred this gate.
+
+## Acceptance Criteria
+
+1. **Given** a clean checkout of current `main` HEAD on a Mac with Xcode 16.x and the `iPhone 17 with Watch` simulator installed, **when** the canonical command `xcodebuild test -project HyzerApp.xcodeproj -scheme HyzerApp -destination 'platform=iOS Simulator,name=iPhone 17 with Watch'` runs end-to-end, **then** the build succeeds, SwiftLint pre-build emits zero warnings, every test suite passes, and the run is captured in `_bmad-output/implementation-artifacts/15-2-evidence/canonical-test-run.txt` (gitignored per the `*-evidence/` glob) — this closes the gate that Stories 9.1, 9.2, 9.3, 14.1, 14.2 all deferred with the same phrase ("simulator unavailable on dev machine").
+
+2. **Given** the test run produces a final pass count, **when** the count is compared to the three figures currently in play (CLAUDE.md "Project Status" — `407 tests`; Story 14.2 Completion Notes — `423 HyzerKit tests + 28 HyzerApp suites`; Story 9.3 AC7 — `278` HyzerKit-package-test baseline), **then** a single authoritative reconciled count is recorded with a per-target breakdown (HyzerKit + HyzerAppTests + any HyzerWatch tests if a watch test target exists). The reconciled count and breakdown replace the existing `407 tests` figure in `CLAUDE.md` "Project Status" and `407 tests` references in `_bmad-output/implementation-artifacts/9-3-*.md` AC7 (the latter is historical — annotate as resolved rather than rewriting).
+
+3. **Given** the `swift test --package-path HyzerKit` (host-only, no simulator) command runs in isolation, **when** its output is parsed, **then** the HyzerKit-only test count matches the per-target breakdown from AC #2 — this validates that the simulator run and the host-only run agree on the HyzerKit portion. Any divergence indicates a HyzerKit test that fails under one runner but not the other (likely a `Task.sleep`-style flake — note in Completion Notes; do not block the AC if the flake is the known `WatchVoiceViewModel` timer test that Story 14.2 dev notes acknowledge).
+
+4. **Given** the canonical command is unavailable on the dev machine (the recurring sim-unavailable pattern from Stories 9.1, 9.2, 9.3, 14.1, 14.2), **when** the dev agent is unable to run the gate, **then** the story stays in `ready-for-dev` and is explicitly deferred to a reviewer with simulator access — the story does NOT get marked `done` based on `swift test --package-path HyzerKit` alone. This AC is the explicit anti-pattern: the half-measure that's been used for five stories in a row.
+
+5. **Given** the canonical run flakes intermittently (one or more tests pass on second run but fail on first), **when** the dev agent observes the flake, **then** the flaky test is recorded by name in Completion Notes with a one-sentence description of its failure mode (e.g., "`WatchVoiceViewModel.test_autoCommitTimerFires` — `Task.sleep`-based assert sometimes finishes before the timer; known debt per Story 14.2 dev notes"). The story can still close if the flake is in the existing `CLAUDE.md` "Known Technical Debt" list (specifically `Task.sleep` flaky-timing tests). New flakes that are not in the known-debt list block the story and require a follow-up.
+
+6. **Given** the reconciled count and breakdown are recorded, **when** `CLAUDE.md` "Project Status" is read, **then** a single sentence documents the canonical baseline going forward (format: "**Test count baseline:** X tests — N1 HyzerKit + N2 HyzerAppTests + N3 HyzerWatch (as of `git rev-parse HEAD` on YYYY-MM-DD).") so future stories quote one number rather than three divergent ones.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Confirm simulator availability on the dev machine** (AC: 1, 4)
+  - [ ] 1.1 Run `xcrun simctl list devices | grep "iPhone 17 with Watch"`. Expected output: at least one matching device with `(Shutdown)` or `(Booted)` status. If output is empty, the simulator is not installed — fall through to AC #4 deferral.
+  - [ ] 1.2 If `iPhone 17 with Watch` is unavailable, check `xcrun simctl list devices | grep "iPhone 17"` for any iPhone 17 variant (Story 14.2 dev notes acknowledge `iPhone 17 Pro` as a fallback when the paired-with-Watch variant is not provisioned). If only a non-Watch-paired variant is available, the watchOS portion of the test target will not run — note this in Completion Notes and proceed with the iOS-only run.
+  - [ ] 1.3 If no `iPhone 17` variant is available at all, the dev machine is sim-incomplete. Surface to the user via Completion Notes: `"Simulator unavailable on dev machine. Per AC #4, this story is deferred to a reviewer with simulator access. No regression test was performed."` Do NOT mark the story `done` in this case.
+
+- [ ] **Task 2: Run the canonical test command** (AC: 1, 5)
+  - [ ] 2.1 On the branch `feature/15-2-canonical-test-baseline-validation` (per CLAUDE.md "Git Workflow"), run the canonical command verbatim: `xcodebuild test -project HyzerApp.xcodeproj -scheme HyzerApp -destination 'platform=iOS Simulator,name=iPhone 17 with Watch' | tee build/canonical-test-run.txt`. Expect `** TEST SUCCEEDED **`. The `tee` ensures the full log is captured for evidence (AC #1).
+  - [ ] 2.2 If the run fails with a non-flake error (compilation error, asset bundle issue, SwiftLint warning at error level), surface the error verbatim — this is a launch-blocker regression and Story 15.2 cannot close until it's fixed. Do NOT attempt to fix the regression in this story; file a new bug-fix story per CLAUDE.md "Bug Fixes Require Tests" and re-run 15.2 after the fix.
+  - [ ] 2.3 If one or more tests fail with the appearance of flake (passes on second run, fails on first), follow AC #5: record the flaky test by name in Completion Notes. If the flake is in CLAUDE.md "Known Technical Debt" (specifically `Task.sleep` patterns), the story can still close — the flake is acknowledged debt. If the flake is new, do NOT close the story; file the new flake as a follow-up story.
+
+- [ ] **Task 3: Copy the canonical run log to the evidence directory** (AC: 1)
+  - [ ] 3.1 Create the evidence directory: `mkdir -p _bmad-output/implementation-artifacts/15-2-evidence/`. The `.gitignore` glob `_bmad-output/implementation-artifacts/*-evidence/` (Story 9.3 Task 6.2) covers it; no additional gitignore edit needed.
+  - [ ] 3.2 Move `build/canonical-test-run.txt` to `_bmad-output/implementation-artifacts/15-2-evidence/canonical-test-run.txt`. The file is gitignored as evidence.
+  - [ ] 3.3 Add a placeholder `README.md` inside the evidence directory with one line: `Evidence from Story 15.2 — canonical test run log. Gitignored.`
+
+- [ ] **Task 4: Reconcile the three divergent test-count figures** (AC: 2)
+  - [ ] 4.1 Parse the canonical run log for the final test count. The Xcode test output line is typically `Test Suite 'All tests' passed at <timestamp>. Executed N tests, with 0 failures (0 unexpected) in M (P) seconds`. Extract `N`.
+  - [ ] 4.2 Parse per-target counts from the same log. Each test target's summary appears separately (`Test Suite 'HyzerKitTests.xctest' passed at <ts>. Executed N1 tests...` and `Test Suite 'HyzerAppTests.xctest' passed at <ts>. Executed N2 tests...`). If a `HyzerWatchTests` target exists, capture its count too.
+  - [ ] 4.3 Compare `N` (total) against the three existing figures (CLAUDE.md: 407, Story 14.2: 423+28-suites, Story 9.3: 278 HyzerKit). Resolve any discrepancy by trusting the live `N` over the historical numbers — the historical figures were correct at their respective points in time but have drifted post-Story-14.2's 10 HyzerKit additions and post-other-story additions.
+  - [ ] 4.4 Edit `CLAUDE.md` "Project Status" section: replace the current `407 tests` line with the reconciled format from AC #6:
+    `**Test count baseline:** N tests — N1 HyzerKit + N2 HyzerAppTests + N3 HyzerWatch (as of git rev-parse HEAD on 2026-MM-DD).`
+    Include the actual commit SHA in the parenthetical so future readers can locate the snapshot.
+
+- [ ] **Task 5: Validate via the host-only HyzerKit run** (AC: 3)
+  - [ ] 5.1 Run `swift test --package-path HyzerKit` (no simulator dependency). Expect the same `N1` count as Task 4.2.
+  - [ ] 5.2 If the host-only count differs from the simulator-derived `N1`, surface to the user — the two should agree (the HyzerKit package is the same code under both runners). Common causes: a flaky test (note per AC #5), a `@testable import` that has different behavior on the macOS host vs. the iOS simulator, or a SwiftPM cache state difference.
+  - [ ] 5.3 If counts agree, record both in Completion Notes for cross-reference.
+
+- [ ] **Task 6: Annotate historical references to the old count** (AC: 2)
+  - [ ] 6.1 Read `_bmad-output/implementation-artifacts/9-3-app-store-connect-record-testflight-test-group-and-border-token-debt.md`. Find every reference to `407 tests` or `278 tests`. Do NOT rewrite the historical text (per Story 15.6's "frozen artifact policy" question — leaving historical numbers in place is also acceptable per that policy). Instead, append a single annotation line at the end of the AC7 section or the relevant Completion Notes section: `_Note (Story 15.2 reconciliation, YYYY-MM-DD): canonical baseline is now N tests (N1 + N2 + N3); the 407/278 figures are historical snapshots._`
+  - [ ] 6.2 Read `_bmad-output/implementation-artifacts/epics-1-8-retro-2026-04-07.md`. Apply the same annotation pattern if the retro references a specific test count that the user wants annotated; otherwise leave the retro untouched per Story 15.6's frozen-artifact policy.
+
+- [ ] **Task 7: Commit and close** (AC: 6)
+  - [ ] 7.1 Stage and commit: `chore(docs): reconcile canonical test baseline (Story 15.2)`. The commit body should quote the final reconciled count from Task 4.
+  - [ ] 7.2 Update `_bmad-output/implementation-artifacts/sprint-status.yaml` — set Story 15.2 from `ready-for-dev` to `done` (or `review` if PR-flow is being followed strictly).
+  - [ ] 7.3 Remove the bullet from `_bmad-output/implementation-artifacts/deferred-work.md` that reads "Run canonical xcodebuild test ... against the 407-test baseline (AC7). Reason for deferral: current machine has no simulator..." (Story 9.2 deferral list).
+
+## Dev Notes
+
+### Why this story exists
+
+Five prior stories (9.1, 9.2, 9.3, 14.1, 14.2) deferred the canonical simulator test gate with the same explanation: "simulator unavailable on dev machine." That deferral chain has reached its limit — TestFlight uploads have happened without a documented green simulator run, and the test-count baseline in CLAUDE.md (`407 tests`) is now out of sync with reality (Story 14.2 added 10 HyzerKit tests; previous stories added others; the actual count is closer to 423 + 28 HyzerApp suites per Story 14.2 Completion Notes). This story closes the gate explicitly: either a reviewer with simulator access runs it, or the story stays open. No more half-measures.
+
+The reconciliation work in Task 4 is bundled because the canonical run produces the authoritative number — separating it into a separate story would force the dev agent to either (a) report two divergent numbers in two PRs or (b) wait for this PR to merge before fixing CLAUDE.md, which is silly.
+
+### Current state — what is already correct (do NOT redo)
+
+- **The test suites themselves are green at the HyzerKit-host level.** `swift test --package-path HyzerKit` passes consistently across all prior dev-agent runs (Story 14.2 reports `413 + 10 = 423 tests` HyzerKit-side, modulo the known `WatchVoiceViewModel` flake).
+- **The `iPhone 17 with Watch` destination is documented in CLAUDE.md "Build & Test Commands"** as canonical. Use it verbatim; do not substitute `iPhone 17 Pro` unless `iPhone 17 with Watch` is genuinely unavailable on the dev machine (Story 14.2 confirmed both can be available).
+- **SwiftLint pre-build emits zero warnings** at the existing rule levels (verified across multiple recent stories). If new warnings appear in Task 2, they are a regression — surface as a launch-blocker per CLAUDE.md "Coding Standards" enforcement.
+- **No `Package.swift`, `project.yml`, or test target additions are in scope.** This story only runs existing tests; if the run reveals a missing test target or broken Package.swift wiring, that is a regression to be filed separately.
+
+### What this story changes
+
+| Change | File | Notes |
+|---|---|---|
+| Replace `407 tests` figure | `CLAUDE.md` "Project Status" | Per AC #6 format |
+| Annotate historical test-count refs | `_bmad-output/implementation-artifacts/9-3-*.md` (AC7 area) | Single line per location; do not rewrite history |
+| Remove resolved bullet | `_bmad-output/implementation-artifacts/deferred-work.md` | The 9.2 "run canonical test" bullet |
+| Create evidence directory | `_bmad-output/implementation-artifacts/15-2-evidence/README.md` | Single placeholder line; gitignored screenshots and log |
+| Sprint status transition | `_bmad-output/implementation-artifacts/sprint-status.yaml` | `ready-for-dev` → `done` (or `review`) |
+
+The committed diff is tiny. The bulk of the work is the simulator run + log capture, which is operational evidence.
+
+### What this story must NOT touch
+
+- **No test additions.** If the canonical run reveals a missing assertion or a gap, file a follow-up — do not expand the test suite in this story.
+- **No production-code changes.** This is a verification-and-documentation story. Even if a SwiftLint warning surfaces, the fix belongs in a separate PR (CLAUDE.md "Bug Fixes Require Tests" — every fix needs its own test, which is out of scope here).
+- **No Package.swift or project.yml changes.** If the test targets need re-wiring, that is itself a story.
+
+### Architecture compliance
+
+- **CLAUDE.md "Bounded queries", "No silent `try?`", "Accessibility first", "Design tokens only":** Inapplicable. No Swift edits.
+- **CLAUDE.md "Git Workflow":** Branch `feature/15-2-canonical-test-baseline-validation`. Conventional commit `chore(docs): reconcile canonical test baseline (Story 15.2)`.
+- **Architecture §Testing (`architecture.md`):** Reaffirms `swift test --package-path HyzerKit` (host) + `xcodebuild test ...` (simulator) as the canonical pair. Story 15.2 enforces both.
+
+### Library / framework requirements
+
+- **No new dependencies.** This story is a verification + reconciliation pass.
+- **`xcodebuild` 16.x** is the required tool; default Xcode 16.x installation suffices.
+
+### File-structure requirements
+
+```
+CLAUDE.md                                                                            [EDIT — Task 4.4]
+_bmad-output/implementation-artifacts/9-3-app-store-connect-record-testflight-test-group-and-border-token-debt.md  [EDIT — Task 6.1, annotation only]
+_bmad-output/implementation-artifacts/deferred-work.md                               [EDIT — Task 7.3, remove resolved bullet]
+_bmad-output/implementation-artifacts/15-2-evidence/README.md                        [NEW — Task 3.3]
+_bmad-output/implementation-artifacts/15-2-evidence/canonical-test-run.txt           [LOCAL ONLY — Task 3.2, gitignored]
+_bmad-output/implementation-artifacts/sprint-status.yaml                             [EDIT — Task 7.2]
+```
+
+Files that must NOT appear in the final diff: any Swift source, any test file, any `Package.swift` or `project.yml`.
+
+### Testing requirements
+
+This story IS the testing requirement — it exists to run the existing tests. No new tests are written. CLAUDE.md "Bug Fixes Require Tests" does not apply: this is not a bug fix, it is a deferred verification gate being closed.
+
+The single new artifact is the canonical run log, captured as gitignored evidence.
+
+### Previous-story intelligence
+
+**Story 9.2 Task 6 explicitly deferred this run:** "Run canonical `xcodebuild test -project HyzerApp.xcodeproj -scheme HyzerApp -destination 'platform=iOS Simulator,name=iPhone 17 with Watch'` against the 407-test baseline (AC7). Reason for deferral: current machine has no simulator." That same explanation appears in 9.1, 9.3, 14.1, and 14.2. Five stories in a row.
+
+**Story 14.2 Completion Notes report `423 HyzerKit + 28 HyzerApp suites`** — this is the most recent test-count snapshot. Task 4 should agree with these numbers ±1 (modulo the `WatchVoiceViewModel` flake noise, which can show ±1).
+
+**Story 9.3 AC7 explicitly preserved the `407` figure** as a baseline expectation at story-creation time. The figure was correct as of `2026-05-16` (the 9.3 creation date) — pre-Story-13.1, pre-Story-13.2, pre-Story-13.3, pre-Story-14.1, pre-Story-14.2 additions. Now it's stale.
+
+**The `WatchVoiceViewModel` auto-commit timer test** is the known flaky test (per Story 14.2 dev notes). It is `Task.sleep`-based and is the canonical example of the debt that Story 15.8 closes. For Story 15.2's purposes, the flake is acknowledged — the story closes if the flake is the only flake observed.
+
+### Latest tech information (2026-05-18)
+
+- **`xcodebuild test` with `-destination 'platform=iOS Simulator,name=iPhone 17 with Watch'`** is the canonical destination per CLAUDE.md. Xcode 16.x supports this destination natively. If the destination string fails to match a simulator, `xcrun simctl list devices` reveals what's installed.
+- **`** TEST FAILED **`** in `xcodebuild` output can be misleading — Story 14.2 Debug Log References note that the indicator can appear even when all 28 suites pass (a known Xcode 16 quirk in heterogeneous test target output). Read the actual final test summary line, not the raw `** TEST <state> **` marker.
+- **`tee build/canonical-test-run.txt`** preserves stdout+stderr in a single file for evidence capture. The `build/` directory is gitignored per Story 9.1.
+
+### Open questions — pre-answered at story-creation time
+
+**Pre-answered:**
+- Canonical destination → `iPhone 17 with Watch` (per CLAUDE.md "Build & Test Commands"); `iPhone 17 Pro` is acceptable fallback per Story 14.2 dev notes
+- Test-count format → `N total — N1 HyzerKit + N2 HyzerAppTests + N3 HyzerWatch (as of git SHA on YYYY-MM-DD)` (per AC #6)
+- Flake policy → known `Task.sleep` flakes acknowledged, new flakes file follow-up stories (per AC #5)
+- Historical annotation → append, do not rewrite (per Story 15.6 frozen-artifact policy question; one-line annotation is the safe minimum)
+
+**Still requires elicitation:**
+- None. All work is mechanical.
+
+### Project Structure Notes
+
+This story's footprint is minimal — one CLAUDE.md edit, one deferred-work.md edit, one annotation line in Story 9.3's file, one evidence directory README. Acceptance is a captured log file (gitignored).
+
+### References
+
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:43` — Story 9.2 deferred canonical test run]
+- [Source: `_bmad-output/implementation-artifacts/14-2-generative-visual-round-signature-on-summary-card.md:546` — `HyzerKit test count: 413 + 10 = 423` snapshot]
+- [Source: `_bmad-output/implementation-artifacts/9-3-app-store-connect-record-testflight-test-group-and-border-token-debt.md:30, 91, 307-309` — 407 + 278 baseline references]
+- [Source: `CLAUDE.md` "Project Status" — current `407 tests` figure]
+- [Source: `CLAUDE.md` "Build & Test Commands" — canonical command syntax]
+- [Source: `CLAUDE.md` "Known Technical Debt" — `Task.sleep` flaky timing acknowledged]
+- [Source: `_bmad-output/planning-artifacts/epics-post-mvp.md#Story-15.2` — this story's epic-level scope]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+<!-- Filled by dev agent during execution -->
+
+### Debug Log References
+
+<!-- Filled by dev agent during execution -->
+
+### Completion Notes List
+
+<!-- Filled by dev agent during execution -->
+
+### File List
+
+<!-- Filled by dev agent during execution -->
+
+### Change Log
+
+<!-- Filled by dev agent during execution -->

--- a/_bmad-output/implementation-artifacts/15-3-generative-signature-ship-gate-verification.md
+++ b/_bmad-output/implementation-artifacts/15-3-generative-signature-ship-gate-verification.md
@@ -1,0 +1,220 @@
+# Story 15.3: Story 14.2 Generative Signature Ship-Gate Manual Verification
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the developer who shipped Story 14.2 without performing the four manual verification sub-tasks (Tasks 8.1–8.5),
+I want documented human-observed evidence that the round signature satisfies AC #3 (palette contrast on `backgroundElevated`), AC #5 (PNG export integrity), AC #6 (VoiceOver announcement), and AC #4 (Reduce Motion behavior),
+So that the merged feature is verified by observation, not inferred from code structure alone, and any contrast failure surfaces before broader-tester rollout.
+
+## Acceptance Criteria
+
+1. **Given** a debug build of current `main` running on a Mac with the `iPhone 17 with Watch` simulator and a fixture round completed with at least 4 players including 1 guest, **when** the round summary card is rendered live, **then** the signature appears between the standings divider and the metadata divider (verifying Story 14.2 Task 6.2 wiring), uses only colors from the 8-token palette enumerated in Story 14.2 Task 3.1, and the rendered output is captured in a screenshot saved at `_bmad-output/implementation-artifacts/15-3-evidence/live-signature-render.png` (gitignored per the `*-evidence/` glob).
+
+2. **Given** Apple's Color Contrast Analyzer (or any 4.5:1-validating tool of equivalent rigor) is run with `Color.backgroundElevated` (#1C1C1E from the dark-first ColorTokens design) as the background, **when** each of the 8 palette entries from Story 14.2 Task 3.1 (`scoreUnderPar`, `scoreAtPar`, `scoreOverPar`, `scoreWayOver`, `accentPrimary`, `textPrimary`, `textSecondary`, `backgroundTertiary`) is measured as foreground, **then** every measurement is recorded in `_bmad-output/implementation-artifacts/15-3-evidence/contrast-report.md` with the ratio and pass/fail-versus-4.5:1 verdict (Story 14.2 spec line 425 explicit requirement). Any palette entry that falls below 4.5:1 is highlighted with a `🟥 FAIL` marker and a follow-up issue is opened naming the entry and proposing either a replacement token or constraining the entry to outline-only treatment (Story 14.2 review-findings deferred bullet).
+
+3. **Given** the live `RoundSummaryView` is displayed for a fixture completed round, **when** the user taps "Share Results" and AirDrops the rendered PNG to a Mac (or saves to Photos), **then** the exported PNG is captured at `_bmad-output/implementation-artifacts/15-3-evidence/exported-summary.png`, the signature region is visually present between the standings and metadata regions in the exported PNG (verifying Story 14.2 AC #5), and the PNG's exact pixel dimensions are recorded in Completion Notes — the height reconciles with the documented 120pt × `displayScale` reserved for the signature (e.g., at 2× scale, expect ~240px of signature region height delta versus the pre-signature snapshot).
+
+4. **Given** VoiceOver is enabled in Settings → Accessibility → VoiceOver and the user swipes through the round summary card live view, **when** the signature element receives focus, **then** the announcement is captured verbatim in Completion Notes (e.g., `"Round signature"`) and matches Story 14.2 AC #6 exactly — not silent, not 32 spoken bytes, not "image", and the signature does NOT announce its constituent hash bytes or palette/geometry detail. Verification is performed BOTH on the live `RoundSummaryView` AND on `HistoryRoundDetailView` re-opening the same completed round (Story 14.2 AC #5 covers both surfaces).
+
+5. **Given** Settings → Accessibility → Motion → Reduce Motion is enabled and the same completed round is re-opened from history, **when** the round summary card is rendered, **then** no animation runs (`AnimationCoordinator.animation(_:reduceMotion:)` returns `.linear(duration: 0)`), the final-frame signature is identical to the no-Reduce-Motion render (verified by capturing both screenshots and comparing visually — Story 14.2 AC #4), and the snapshot-exported PNG is byte-identical between Reduce-Motion-enabled and Reduce-Motion-disabled paths (Story 14.2 AC #4 explicit invariant: "Static rendering MUST match the final animated frame pixel-for-pixel").
+
+6. **Given** all four verification artifacts (live screenshot, contrast report, exported PNG, Reduce Motion comparison) are captured, **when** the story closes, **then** Completion Notes summarize the result with a single sentence: `"All four Story 14.2 ship-gate verifications complete. AC #3 / #4 / #5 / #6 satisfied. [N] palette entries failed contrast threshold (4.5:1 against backgroundElevated): [list, or 'none']. Follow-up issues filed: [list, or 'none']."` The bullet in `_bmad-output/implementation-artifacts/deferred-work.md` referencing Story 14.2 Task 8.1–8.5 manual verification is removed.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Build and launch on simulator** (AC: 1)
+  - [ ] 1.1 Confirm simulator availability per Story 15.2 Task 1 — `iPhone 17 with Watch` preferred, `iPhone 17 Pro` fallback (Story 14.2 dev notes acknowledge fallback). If neither is available, the story is fully deferred to a reviewer; do NOT proceed with the host-only path because the live-render and AirDrop ACs cannot be validated without a simulator.
+  - [ ] 1.2 Build a debug configuration of HyzerApp from current `main`: `xcodebuild -project HyzerApp.xcodeproj -scheme HyzerApp -destination 'platform=iOS Simulator,name=iPhone 17 with Watch' -configuration Debug build`. The build artifact lives in DerivedData.
+  - [ ] 1.3 Launch the app in the simulator. Onboard with a display name. Create a fixture round with 4 players (including 1 guest) on any seeded course. Score the round to completion via tap scoring (the fastest path).
+  - [ ] 1.4 Once the round transitions to `.completed`, the round summary card appears. Verify visually that the signature is present between the standings divider and the metadata divider — this confirms Story 14.2 Task 6.2 wiring is intact.
+  - [ ] 1.5 Capture a screenshot of the live round summary view (signature visible) to `_bmad-output/implementation-artifacts/15-3-evidence/live-signature-render.png`. Use the simulator's native screenshot command (`Cmd-S` or `xcrun simctl io booted screenshot`).
+
+- [ ] **Task 2: Palette contrast spot-check against `backgroundElevated`** (AC: 2)
+  - [ ] 2.1 Open Apple's Color Contrast Analyzer (free, from `https://developer.apple.com/design/human-interface-guidelines/color`) or another 4.5:1-validating tool. Story 14.2 dev notes also reference this as the verification method (line 455).
+  - [ ] 2.2 Read the 8 palette colors from `HyzerKit/Sources/HyzerKit/Design/ColorTokens.swift` to capture their actual hex values (the tokens reference dark-first specs; confirm by reading the file). The 8 tokens to check are listed in Story 14.2 Task 3.1: `scoreUnderPar`, `scoreAtPar`, `scoreOverPar`, `scoreWayOver`, `accentPrimary`, `textPrimary`, `textSecondary`, `backgroundTertiary`.
+  - [ ] 2.3 Read the `backgroundElevated` value from the same file (expected: `#1C1C1E` per Story 14.2 dev notes line 455).
+  - [ ] 2.4 Measure each foreground/background pair. Record results in a markdown table at `_bmad-output/implementation-artifacts/15-3-evidence/contrast-report.md`:
+    ```
+    | Token | Hex | Contrast vs. backgroundElevated (#1C1C1E) | Result |
+    |---|---|---|---|
+    | scoreUnderPar | #... | X.YZ:1 | 🟩 PASS / 🟥 FAIL |
+    | ... | ... | ... | ... |
+    ```
+  - [ ] 2.5 For every entry that falls below 4.5:1, append a short follow-up note documenting one of two options: (a) replace the token in the signature palette with an alternative that passes, OR (b) constrain the failing token to outline-only treatment in `RoundSignature` (which has lower contrast requirements than a solid fill). Do NOT make the code change in this story — file the follow-up as a separate issue per Story 14.2 review-findings deferral.
+  - [ ] 2.6 If ALL entries pass, note in Completion Notes: `"All 8 palette entries clear 4.5:1 against backgroundElevated. No follow-up required."`
+
+- [ ] **Task 3: PNG export and AirDrop verification** (AC: 3)
+  - [ ] 3.1 From the round summary view in Task 1.4, tap "Share Results" (the bottom-of-card primary CTA per Story 11.3). The system share sheet appears.
+  - [ ] 3.2 Select "AirDrop" → the host Mac. The PNG transfers. Save the received PNG to `_bmad-output/implementation-artifacts/15-3-evidence/exported-summary.png`. If AirDrop is unavailable (e.g., the sim → Mac AirDrop path is finicky), use the alternative path from Story 11.3: tap "Save to Photos" or "Copy" the image to the clipboard, then save manually to the same evidence path.
+  - [ ] 3.3 Open the exported PNG in Preview. Verify the signature region is visually present between the standings region and the metadata footer. If the signature is missing from the exported PNG, this is a regression of Story 14.2 AC #5 — surface as a launch-blocker bug, do NOT close this story.
+  - [ ] 3.4 Read the PNG's exact pixel dimensions (Preview → Tools → Show Inspector). Record in Completion Notes: `"Exported PNG: WxH pixels at displayScale 2.0. Signature region: ~240px high (120pt × 2.0)."` The expectation is approximate — Story 14.2 AC #5 documents the height delta as `120 × displayScale`.
+
+- [ ] **Task 4: VoiceOver verification** (AC: 4)
+  - [ ] 4.1 In the simulator's Settings → Accessibility → VoiceOver → toggle ON. The simulator now narrates focused elements.
+  - [ ] 4.2 Navigate back to the round summary card (live `RoundSummaryView`). Swipe right through the elements: header → course name → date → standings rows → signature → metadata.
+  - [ ] 4.3 When the signature receives focus, capture the spoken announcement verbatim in Completion Notes. Expected: `"Round signature"` (per Story 14.2 AC #6). If the announcement is silent, "image", or includes hash bytes / palette names / geometry detail, this is a regression — surface and do NOT close this story.
+  - [ ] 4.4 Repeat the swipe-through on `HistoryRoundDetailView` (navigate via Home → History → select the same completed round). The signature on the history detail view goes through the same `SummaryCardSnapshotView` code path and should announce identically. Confirm the announcement.
+  - [ ] 4.5 Disable VoiceOver before proceeding to Task 5.
+
+- [ ] **Task 5: Reduce Motion verification** (AC: 5)
+  - [ ] 5.1 In Settings → Accessibility → Motion → toggle Reduce Motion ON.
+  - [ ] 5.2 Force-quit the app in the simulator (Cmd-Shift-H twice → swipe up on the app card). Relaunch from the home screen. (Reduce Motion is read at render time; force-quit ensures a fresh render.)
+  - [ ] 5.3 Navigate to History → select the same completed round → view the round summary. Capture a screenshot of the Reduce-Motion render at `_bmad-output/implementation-artifacts/15-3-evidence/reduce-motion-render.png`.
+  - [ ] 5.4 Compare `reduce-motion-render.png` against `live-signature-render.png` (Task 1.5). Per Story 14.2 AC #4, the two MUST be visually identical — the static rendering must match the final animated frame pixel-for-pixel. If they differ, the Reduce-Motion code path is producing a different layout — surface as a Story 14.2 AC #4 regression, do NOT close this story.
+  - [ ] 5.5 Trigger the share flow again (Task 3.1–3.2) under Reduce Motion. Save the exported PNG to `_bmad-output/implementation-artifacts/15-3-evidence/reduce-motion-exported.png`. Compare byte-equality against `exported-summary.png` (Task 3.2) using `shasum -a 256 exported-summary.png reduce-motion-exported.png` or `cmp exported-summary.png reduce-motion-exported.png`. Expected: identical SHAs / `cmp` returns 0. If they differ, the Reduce-Motion-on snapshot path is doing something non-deterministic — surface as an AC #4 regression.
+  - [ ] 5.6 Disable Reduce Motion before closing.
+
+- [ ] **Task 6: Compile findings and close** (AC: 6)
+  - [ ] 6.1 Write the Completion Notes summary in the format from AC #6: list any contrast failures (with token names), list any follow-up issues filed (with issue links if available), and confirm the 4 ACs.
+  - [ ] 6.2 Stage and commit: `chore(verify): close Story 14.2 ship-gate manual verifications (Story 15.3)`. No Swift source files are touched. The diff is the evidence README and (optionally) the deferred-work.md cleanup.
+  - [ ] 6.3 Update `_bmad-output/implementation-artifacts/deferred-work.md` — remove the bullet under `## Deferred from: code review of 14-2-generative-visual-round-signature-on-summary-card (2026-05-18)` (currently line 3). If contrast failures were found, REPLACE the bullet with a new entry naming the failure (e.g., `- Story 15.3 verification revealed Color.textSecondary at 3.8:1 against backgroundElevated. Follow-up filed [link].`).
+  - [ ] 6.4 Update `_bmad-output/implementation-artifacts/sprint-status.yaml` — set Story 15.3 from `ready-for-dev` to `done` (or `review`).
+
+## Dev Notes
+
+### Why this story exists
+
+Story 14.2 closed and merged 2026-05-18 with all 10 ACs technically satisfied via code structure — but Tasks 8.1–8.5 (the manual verifications) were explicitly not performed by the dev agent (Completion Notes line 544: "Manual verification (Task 8) — not performed interactively by dev agent (non-interactive execution context). Implementation satisfies requirements by code review."). Story 14.2's review-findings explicitly flagged this as a defer with a strong recommendation for human verification BEFORE merge — but the merge happened anyway (commit `e76d305`, two days before this story-creation date).
+
+The four ACs being verified are not nice-to-have polish — three of them are direct user-facing quality gates:
+- **AC #3 contrast spot-check** (Story 14.2 spec line 425): "Do NOT proceed past Task 4 without checking this." `textSecondary` and `backgroundTertiary` are explicitly called out as higher-risk against the lighter `backgroundElevated` background; a failure means a signature element is invisible/illegible.
+- **AC #5 PNG export integrity**: The screenshot-first design (UX-PMVP-DR1) depends on the signature appearing in shares. If the exported PNG is missing the signature, the feature is broken for the primary use case (sharing rounds to group chat).
+- **AC #6 VoiceOver**: A signature that announces 32 hash bytes is a critical accessibility failure (~50 seconds of meaningless speech per Story 14.2 AC #6 commentary).
+- **AC #4 Reduce Motion**: A divergence between animated and static render would mean the snapshot PNG differs from the live preview, breaking determinism (AC #1).
+
+This story closes the loop.
+
+### Current state — what is already correct (do NOT redo)
+
+- **All Story 14.2 Swift implementation is complete.** `RoundSignatureInput`, `RoundSignatureHasher`, `RoundSignature`, and the wiring into `RoundSummaryViewModel` + `RoundSummaryView` + `SummaryCardSnapshotView` are all in place per Story 14.2 File List. This story does NOT re-implement anything.
+- **All Story 14.2 automated tests pass.** 10 HyzerKit tests + 6 HyzerApp tests — confirmed in Story 14.2 Completion Notes. The pixel-determinism test (Task 7.4) is the corroborating evidence for AC #1; this story verifies AC #3 / #4 / #5 / #6 separately.
+- **The `*-evidence/` gitignore glob is in place** (Story 9.3 Task 6.2). Creating `15-3-evidence/` requires only `mkdir`.
+
+### What this story changes (and does NOT change)
+
+**Changes:**
+- Captures 4–6 evidence artifacts (screenshots + log + contrast report markdown)
+- Adds a one-line evidence directory README
+- Updates Completion Notes with the verbatim VoiceOver utterance and PNG dimensions
+- Removes one bullet from `deferred-work.md` (or replaces it with a follow-up note if contrast failures surface)
+
+**Does NOT change:**
+- Any Swift source file
+- Any test file
+- Any production behavior of `RoundSignature` or its callers
+- The Story 14.2 implementation (out of scope; this story OBSERVES, does not modify)
+
+If a contrast failure surfaces, the fix is FILED, not implemented in this story. Story 15.3 closes when the verification is complete; the fix is a follow-up.
+
+### Architecture compliance
+
+- **CLAUDE.md "Accessibility first":** This story is the literal enforcement of that rule. VoiceOver verification + contrast measurement are the operationalization of the accessibility-first commitment.
+- **CLAUDE.md "Design tokens only":** Verified by Task 2 — every signature color must come from `ColorTokens`.
+- **CLAUDE.md "Git Workflow":** Branch `feature/15-3-story-14-2-manual-verification`. Conventional commit `chore(verify): close Story 14.2 ship-gate manual verifications`.
+- **Architecture §UX (`architecture.md` design system section):** The signature is constrained by UX-PMVP-DR6 to "geometric or color-derived treatment that fits the existing dark-dominant palette." Task 2's contrast check enforces the "fits the palette" half.
+
+### Library / framework requirements
+
+- **No new dependencies.** All verification is done in the simulator and on the host Mac with built-in tools (Color Contrast Analyzer ships with Xcode-adjacent dev tools; AirDrop is built into macOS; Preview is built into macOS; `shasum` / `cmp` are POSIX).
+- **Simulator requirement:** `iPhone 17 with Watch` per CLAUDE.md; `iPhone 17 Pro` acceptable fallback. If the dev machine has neither, the story is fully deferred (Task 1.1).
+
+### File-structure requirements
+
+```
+_bmad-output/implementation-artifacts/15-3-evidence/README.md                     [NEW — Task 1]
+_bmad-output/implementation-artifacts/15-3-evidence/live-signature-render.png     [LOCAL ONLY — Task 1.5]
+_bmad-output/implementation-artifacts/15-3-evidence/contrast-report.md            [LOCAL ONLY — Task 2.4]
+_bmad-output/implementation-artifacts/15-3-evidence/exported-summary.png          [LOCAL ONLY — Task 3.2]
+_bmad-output/implementation-artifacts/15-3-evidence/reduce-motion-render.png      [LOCAL ONLY — Task 5.3]
+_bmad-output/implementation-artifacts/15-3-evidence/reduce-motion-exported.png    [LOCAL ONLY — Task 5.5]
+_bmad-output/implementation-artifacts/deferred-work.md                            [EDIT — Task 6.3]
+_bmad-output/implementation-artifacts/sprint-status.yaml                          [EDIT — Task 6.4]
+```
+
+Note: ALL files in the evidence directory ARE gitignored per the `*-evidence/` glob. The commit diff is the README + deferred-work.md + sprint-status.yaml. The actual evidence lives locally; reviewers must reproduce the verification if they want to re-validate.
+
+Files that must NOT appear in the diff: any Swift source, any test file, `RoundSignature.swift`, `RoundSummaryViewModel.swift`, or `RoundSummaryView.swift`.
+
+### Testing requirements
+
+This story performs manual verification of existing tested code. No new automated tests are added. Story 14.2's existing test suite is the automated baseline; this story is the visual + accessibility supplement.
+
+### Previous-story intelligence
+
+**Story 14.2 review-findings deferral (line 354 in 14-2-*.md):**
+> [Review][Defer] Manual verification (Task 8.1–8.5) and palette-on-`backgroundElevated` contrast check [Story 11.2 intelligence at spec line 425] — Completion Notes state Task 8 was not performed interactively. Spec line 425 explicitly requires a contrast spot-check of each palette token against Color.backgroundElevated ("Do NOT proceed past Task 4 without checking this") — textPrimary, textSecondary, backgroundTertiary may render with insufficient contrast against the elevated background. Recommend human verification on simulator before merge.
+
+Story 15.3 is the explicit close of that deferral.
+
+**Story 11.2 contrast intelligence (Story 14.2 line 455):** "Contrast tokens checked at 11.2: all score-state colors against Color.backgroundPrimary are ≥5.8:1 (AA pass; scoreWayOver misses AAA by ~1.2 units, documented as known). Signature draws against Color.backgroundElevated (#1C1C1E), which is slightly lighter than backgroundPrimary (#0A0A0C) — contrast will be marginally LOWER. Spot-check via the same method (Color Contrast Analyzer): each palette color against backgroundElevated."
+
+This is the methodology Task 2 uses verbatim.
+
+**Story 14.2 Task 8 verbatim sub-tasks (lines 326–330):**
+- 8.1 In a debug build, complete a round on a simulator and observe the round summary card. Confirm: signature appears between standings and metadata; uses only token colors; no emoji/glyphs/text/illustrations.
+- 8.2 Tap "Share Results" and AirDrop the PNG to a Mac or copy to Notes. Open at 100% zoom — confirm the signature is part of the exported image and matches what you see in the live view.
+- 8.3 Open Settings → Accessibility → Motion → enable Reduce Motion. Reopen the same completed round from history. Confirm: no animation runs; the final-frame signature is identical to what showed in step 8.1.
+- 8.4 Enable VoiceOver. Swipe through the round summary card. Confirm the signature announces as "Round signature" and not as 32 spoken bytes.
+- 8.5 Record the exported PNG's dimensions in Completion Notes for the AC #5 height verification.
+
+Story 15.3 Tasks 1–5 map 1:1 onto these sub-tasks. The intent is to perform them faithfully.
+
+### Latest tech information (2026-05-18)
+
+- **Simulator screenshot path:** `xcrun simctl io booted screenshot ~/Desktop/sim.png` works on Xcode 16. Alternative: Cmd-S in the simulator UI.
+- **AirDrop simulator → Mac path:** Has been finicky on Xcode 16; fallback is "Save to Files" or "Save to Photos" then drag from the sim's Photos app to the Mac (or use the sim's drag-to-Mac gesture).
+- **Color Contrast Analyzer** is the canonical Apple-recommended tool for this verification. Free download from Apple's HIG site. Inputs are hex values; outputs are ratios and pass/fail markers.
+
+### Open questions — pre-answered
+
+**Pre-answered:**
+- Methodology for contrast check → Color Contrast Analyzer with `#1C1C1E` background (per Story 14.2 line 455)
+- Threshold → 4.5:1 (AA pass; Story 14.2 spec)
+- VoiceOver expected utterance → "Round signature" (Story 14.2 AC #6)
+- Reduce Motion expected behavior → static render byte-identical to live render (Story 14.2 AC #4)
+- Evidence storage → gitignored `*-evidence/` glob (per Story 9.3 Task 6.2)
+
+**Still requires elicitation:** none — all expected values are explicit in Story 14.2.
+
+### Project Structure Notes
+
+This story is a verification story: it produces evidence, not code. The committed diff is tiny — a README and minor doc edits. The evidence directory captures the bulk of the work but is gitignored to avoid bloating the repo with large screenshots.
+
+### References
+
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:3` — Story 14.2 manual verification deferral]
+- [Source: `_bmad-output/implementation-artifacts/14-2-generative-visual-round-signature-on-summary-card.md` — Story 14.2 full spec, ACs, Task 8 sub-tasks, Completion Notes acknowledging non-execution]
+- [Source: `_bmad-output/implementation-artifacts/14-2-generative-visual-round-signature-on-summary-card.md:354` — Review-finding deferral text]
+- [Source: `_bmad-output/implementation-artifacts/14-2-generative-visual-round-signature-on-summary-card.md:455` — Contrast methodology from Story 11.2]
+- [Source: `_bmad-output/implementation-artifacts/14-2-generative-visual-round-signature-on-summary-card.md:326-330` — Task 8 verbatim sub-tasks]
+- [Source: `HyzerKit/Sources/HyzerKit/Design/ColorTokens.swift` — palette and `backgroundElevated` definitions]
+- [Source: `HyzerApp/Views/Components/RoundSignature.swift` — the component being verified]
+- [Source: `HyzerApp/Views/Scoring/RoundSummaryView.swift` — both live and snapshot integration sites]
+- [Source: `CLAUDE.md` "Accessibility first" — design-system rule being enforced]
+- [Source: `_bmad-output/planning-artifacts/epics-post-mvp.md#Story-15.3` — this story's epic-level scope]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+<!-- Filled by dev agent during execution -->
+
+### Debug Log References
+
+<!-- Filled by dev agent during execution -->
+
+### Completion Notes List
+
+<!-- Filled by dev agent during execution -->
+
+### File List
+
+<!-- Filled by dev agent during execution -->
+
+### Change Log
+
+<!-- Filled by dev agent during execution -->

--- a/_bmad-output/implementation-artifacts/15-4-on-device-history-services-performance-verification.md
+++ b/_bmad-output/implementation-artifacts/15-4-on-device-history-services-performance-verification.md
@@ -1,0 +1,245 @@
+# Story 15.4: On-Device History-Services Performance Verification
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the developer claiming PMVP-NFR4 satisfaction (`PlayerTrendService` renders `<500ms` for 250-round histories),
+I want the on-device measurement performed on a physical iPhone 12+ at 250 rounds, plus device-time baselines for `PersonalBestService.computeBest` and `HeadToHeadService.computeRecord`,
+So that AC #3 of Story 13.1 has device-measured evidence and adjacent history services have a documented regression bar that future PRs can compare against.
+
+## Acceptance Criteria
+
+1. **Given** a release-configuration Hyzer build is installed on a physical iPhone 12+ running iOS 18+ (no simulator — Story 13.1 explicitly excluded macOS x86 simulator measurements as the basis for AC #3, noting the simulator-measured time was `~0.84s` for 250 rounds), **when** a fixture player with exactly 250 completed rounds is loaded into SwiftData and `PlayerTrendView` is presented for that player, **then** the median time from view-appear to first-paint of the chart over 5 invocations is `<500ms` (PMVP-NFR4; Story 13.1 AC #3). Measurement methodology uses `os_signpost` markers wrapped around `PlayerTrendService.computeTrend(playerID:maxRounds:)` AND the SwiftUI rendering frame timeline; both numbers are recorded — the dominant cost should be the service call.
+
+2. **Given** the same fixture player + course is loaded, **when** `PersonalBestService.computeBest(playerID:courseID:)` is invoked 5 times, **then** the median time is recorded as the on-device baseline for the service. There is NO formal `<500ms` budget for `PersonalBestService` in any prior story — this AC establishes the baseline number for future regression comparison. The expected ballpark is `<200ms` at the PMVP `maxRounds = 500` bound (Story 13.2 dev notes).
+
+3. **Given** the same fixture player + a second fixture player who participated in at least 10 of the 250 rounds, **when** `HeadToHeadService.computeRecord(playerA:playerB:)` is invoked 5 times, **then** the median time is recorded as the on-device baseline. As with AC #2, no formal budget exists — this AC establishes a baseline. The expected ballpark is `<300ms` (HeadToHead loops the per-round StandingsEngine recompute, so it should be more expensive than PB but bounded).
+
+4. **Given** any single measurement (PlayerTrend, PersonalBest, or HeadToHead) exceeds an informal regression threshold (`PlayerTrend >500ms`, `PB >2s`, `HeadToHead >3s`), **when** the failure surfaces during verification, **then** Story 15.4 still closes (the measurement was performed), the failing number is recorded in Completion Notes, AND a follow-up story is filed naming the service and proposing an optimization approach (batched fetch, indexed predicate, etc.). Failing AC #1's `<500ms` budget for PlayerTrend is a launch-relevant signal — flag in Completion Notes with "BLOCKER for AC claim of PMVP-NFR4."
+
+5. **Given** the three median numbers are recorded, **when** Story 13.1's AC #3 is re-read, **then** either (a) AC #3 is now claimed as fully satisfied because the device measurement is at-or-below 500ms (Story 13.1 Completion Note #8 currently states this is not claimed), OR (b) AC #3 is explicitly flagged as not satisfied with the device number documented (informing whether PlayerTrendService needs optimization before launch). The decision is recorded in `_bmad-output/implementation-artifacts/15-4-evidence/perf.md`.
+
+6. **Given** the seeding script and measurement results are committed, **when** the `_bmad-output/implementation-artifacts/deferred-work.md` Story 13.1 AC #3 deferral bullet is read, **then** the bullet is removed and replaced with the on-device number (e.g., `- AC #3 PlayerTrendService measurement: 380ms on iPhone 14 (median of 5 runs, fixture: 250 rounds). PMVP-NFR4 satisfied. [Story 15.4]`).
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Identify and provision the test device** (AC: 1)
+  - [ ] 1.1 **User elicitation:** Before any work, ask the user for (a) which physical iPhone is available for testing (the device must be iPhone 12 or later per Story 14.2 dev notes — Apple A14 Bionic or newer), (b) whether the user can install a debug or release build via Xcode for ~30 minutes of testing, (c) the iCloud account the device should be signed into (test-only Apple ID preferred so it doesn't pollute the developer's primary iCloud with fixture rounds).
+  - [ ] 1.2 If no physical device is available, the story is fully deferred to the user-provided-device path — Story 15.4 stays `ready-for-dev` with an explicit Completion Note: `"No physical device available. Deferred to next session with hardware access. AC #3 of Story 13.1 remains unclaimed."` Do NOT close the story based on simulator measurements.
+  - [ ] 1.3 Confirm Xcode 16.x is installed and the device is paired (in `xcrun xctrace list devices`). The device should appear with `(<udid>)` and a non-error status.
+
+- [ ] **Task 2: Build and install the test bundle** (AC: 1, 2, 3)
+  - [ ] 2.1 Build a Release-configuration of HyzerApp (release-config exercises optimizations that simulator-debug does not, more closely matching TestFlight install path): `xcodebuild -project HyzerApp.xcodeproj -scheme HyzerApp -configuration Release -destination "platform=iOS,name=<device-name>" build`. Expect `** BUILD SUCCEEDED **`.
+  - [ ] 2.2 Install on the device. The simplest path is Xcode's Product → Destination → physical device → Cmd-R. This installs the freshly-built artifact and launches the app under the debugger (signpost markers require the debugger or Instruments to be attached).
+  - [ ] 2.3 Verify the app launches to the onboarding screen on the device. Onboard with a fixture display name (e.g., `Perf-Tester-15-4`).
+
+- [ ] **Task 3: Seed 250 fixture rounds for the test player** (AC: 1)
+  - [ ] 3.1 The codebase does NOT have a public 250-round seeding script (Story 13.1 dev notes describe a similar measurement using fixture-construction-loops in tests, not a runtime seeding harness). For Story 15.4's purposes, the seeding can be done via a debug-only `#if DEBUG` block in `HyzerApp/App/HyzerApp.swift` that creates 250 `Round` + 250 × 18 `ScoreEvent` records into the SwiftData store on a triggered action.
+  - [ ] 3.2 Implement a single `#if DEBUG`-guarded `Button("Seed 250 Rounds")` in a debug-only `HyzerApp/Views/Debug/PerfTestSeederView.swift` that calls `await SeedHelper.seed250Rounds(into: modelContext)`. The seed helper lives in `HyzerKit/Sources/HyzerKit/Domain/SeedHelper.swift` and constructs 250 deterministic rounds with the test player as a participant, distributed across the 4 pre-seeded courses (Story 1.3) at 60+ rounds each, with stroke counts varying from `-10` to `+15` over par to exercise the score-state palette.
+  - [ ] 3.3 Run the seeder once on the device. Wait for completion (expected <30 seconds). Verify by navigating to History and confirming 250 rounds are visible.
+  - [ ] 3.4 **IMPORTANT:** The seeder code is `#if DEBUG`-guarded so it does not ship in Release builds. After this story closes, the seeder remains in the codebase for future perf measurements. Story 15.7's TestSupport extraction may later relocate `SeedHelper` — out of scope here.
+
+- [ ] **Task 4: Measure `PlayerTrendService.computeTrend` on device** (AC: 1, 5)
+  - [ ] 4.1 With the device attached to Xcode and Instruments not yet running, open Instruments → Time Profiler + os_signpost. Target: HyzerApp on the device.
+  - [ ] 4.2 Wrap the `PlayerTrendService.computeTrend(playerID:maxRounds:)` call in `os_signpost`:
+    ```swift
+    let log = Logger.player_trend
+    let signpostID = log.makeSignpostID()
+    let state = log.beginSignpost("computeTrend", id: signpostID)
+    defer { log.endSignpost("computeTrend", id: signpostID, state: state) }
+    return await service.computeTrend(...)
+    ```
+    Add this wrapping in `PlayerTrendViewModel.load()` (or wherever the service is invoked). The wrapping is debug-only (`#if DEBUG`); remove from production code path in Story 15.4 cleanup, OR retain as documented instrumentation per CLAUDE.md observability rules (decide in Completion Notes).
+  - [ ] 4.3 Open the player's trend view 5 times in a row, force-quitting between each (Cmd-Shift-H twice → swipe up). Instruments records 5 signpost intervals.
+  - [ ] 4.4 Read the 5 signpost durations in Instruments. Compute the median (middle value when sorted). Record in `_bmad-output/implementation-artifacts/15-4-evidence/perf.md` as a row:
+    ```
+    | Run | Duration (ms) |
+    |---|---|
+    | 1 | XXX |
+    | 2 | XXX |
+    | 3 | XXX |
+    | 4 | XXX |
+    | 5 | XXX |
+    | **Median** | **XXX** |
+    ```
+  - [ ] 4.5 If median exceeds 500ms, AC #1 is failed — record verbatim in Completion Notes with the device name (`iPhone 14`, etc.) and iOS version. File a follow-up story per AC #4.
+
+- [ ] **Task 5: Measure `PersonalBestService.computeBest` on device** (AC: 2)
+  - [ ] 5.1 Repeat the signpost wrapping in `PersonalBestViewModel.load()` (or wherever the service is invoked). Use a separate `Logger.personal_best` source so the signposts don't intermix in Instruments.
+  - [ ] 5.2 Open the course detail view for a course where the test player has at least 60 rounds. The personal-best section renders, triggering the service call. Repeat 5 times.
+  - [ ] 5.3 Record median in `perf.md`.
+
+- [ ] **Task 6: Measure `HeadToHeadService.computeRecord` on device** (AC: 3)
+  - [ ] 6.1 Repeat the signpost wrapping in `HeadToHeadViewModel.load()`.
+  - [ ] 6.2 Open the head-to-head view with the test player vs. a second seeded player (the seeder in Task 3 should include a second participant in every round). Repeat 5 times.
+  - [ ] 6.3 Record median in `perf.md`.
+
+- [ ] **Task 7: Compile findings and update Story 13.1 AC #3 claim** (AC: 5, 6)
+  - [ ] 7.1 Compose `perf.md` with the three median numbers, the device used, iOS version, the date measured, and a single-sentence verdict:
+    ```
+    # Story 15.4 — On-Device Performance Verification
+
+    **Device:** iPhone 14 (iOS 18.2)
+    **Date:** 2026-MM-DD
+    **Build:** Release configuration, HEAD <SHA>
+    **Fixture:** 250 rounds via SeedHelper.seed250Rounds()
+
+    ## PlayerTrendService.computeTrend
+    [table from Task 4.4]
+    **Verdict:** 🟩 PASS (<500ms median) / 🟥 FAIL (>500ms median)
+    **Story 13.1 AC #3 claim:** Now satisfied / Still unclaimed
+
+    ## PersonalBestService.computeBest
+    [table from Task 5.3]
+    **Baseline established:** XXXms (no prior budget)
+
+    ## HeadToHeadService.computeRecord
+    [table from Task 6.3]
+    **Baseline established:** XXXms (no prior budget)
+    ```
+  - [ ] 7.2 If AC #1 passes, update Story 13.1 by appending a single line to its Completion Notes section: `"AC #3 device measurement performed in Story 15.4. Median: XXXms on iPhone <model> (iOS <version>). Now claimed as satisfied."` Do NOT rewrite Story 13.1's text; just append.
+  - [ ] 7.3 If AC #1 fails, update Story 13.1 with the failed number and a note that an optimization is needed before launch. File the follow-up story.
+
+- [ ] **Task 8: Cleanup and close** (AC: 6)
+  - [ ] 8.1 Decide whether to retain the `os_signpost` instrumentation in production code paths (CLAUDE.md observability guidance allows it; running cost is negligible). If retained, ensure the `#if DEBUG` flags are removed and the Logger source is documented in CLAUDE.md "Observability". If removed, strip the signpost code from the three viewmodels — leave no dead `#if DEBUG` blocks.
+  - [ ] 8.2 Stage and commit. The diff includes: `SeedHelper.swift` (debug-guarded), `PerfTestSeederView.swift` (debug-guarded), optional `os_signpost` instrumentation in the three viewmodels, `perf.md` in the evidence directory (gitignored), and `deferred-work.md` cleanup. Conventional commit: `chore(perf): verify history services on-device (Story 15.4)`.
+  - [ ] 8.3 Remove the Story 13.1 AC #3 bullet from `_bmad-output/implementation-artifacts/deferred-work.md` and replace with the on-device number per AC #6.
+  - [ ] 8.4 Update `_bmad-output/implementation-artifacts/sprint-status.yaml` — Story 15.4 → `done` (or `review`).
+
+## Dev Notes
+
+### Why this story exists
+
+Story 13.1's AC #3 demands a `<500ms` render time at 250 rounds — PMVP-NFR4. Story 13.1's dev agent measured this on a macOS x86 test runner and got `~0.84s` (Completion Note #8). The Completion Note explicitly states this is NOT a claim of AC #3 satisfaction — device measurement is needed. Two stories later (14.1, 14.2), the device measurement still hasn't happened. This story closes it.
+
+The two adjacent services (`PersonalBest`, `HeadToHead`) are bundled because (a) they share the same SwiftData fetch patterns, (b) measuring all three on the same device in one session is more efficient than three separate stories, and (c) establishing on-device baselines for the two unbudgeted services creates a regression bar that future PRs can compare against.
+
+The seeding harness is created in this story because no public 250-round seeding tool exists in the codebase. The harness is debug-only (`#if DEBUG`) so it does not ship in TestFlight or production builds — Apple does not see it.
+
+### Current state — what is already correct (do NOT redo)
+
+- **`PlayerTrendService`, `PersonalBestService`, `HeadToHeadService` are implemented and tested.** Stories 13.1, 13.2, 13.3 closed. All bounded by `fetchLimit`. All measured on the host via the existing performance tests in HyzerKitTests. This story adds the device measurement, not new code.
+- **The 4 pre-seeded courses (Story 1.3) provide enough distribution for the fixture.** 250 rounds distributed across 4 courses gives ~60 rounds per course, which is more than enough for PersonalBest and HeadToHead measurements.
+- **`os_signpost` and `Logger` are the canonical observability tools per CLAUDE.md.** No new framework needed.
+- **The `*-evidence/` gitignore glob is in place.**
+
+### What this story changes
+
+| Change | File | Notes |
+|---|---|---|
+| Add seed helper | `HyzerKit/Sources/HyzerKit/Domain/SeedHelper.swift` | NEW, debug-only or always-available |
+| Add debug seeder view | `HyzerApp/Views/Debug/PerfTestSeederView.swift` | NEW, `#if DEBUG` |
+| Optional: add os_signpost | `HyzerApp/ViewModels/PlayerTrendViewModel.swift`, `PersonalBestViewModel.swift`, `HeadToHeadViewModel.swift` | Decide in Completion Notes whether to retain |
+| Evidence | `_bmad-output/implementation-artifacts/15-4-evidence/perf.md` | LOCAL ONLY, gitignored |
+| Story 13.1 update | `_bmad-output/implementation-artifacts/13-1-*.md` | Append-only Completion Note line |
+| Deferred-work cleanup | `_bmad-output/implementation-artifacts/deferred-work.md` | Replace 13.1 AC #3 bullet with device number |
+
+The seed helper is intentionally simple — 250 rounds, deterministic, fixed across runs. No random scoring, no edge-case round types. Just a baseline-establishing fixture.
+
+### What this story must NOT touch
+
+- **No production-code optimization.** If a measurement reveals a service is slow, file a follow-up — do NOT optimize in this story. Optimization is a separate scope.
+- **No new service additions.** Don't add a fourth history service. Don't add a "PlayerStreakService" or similar.
+- **No test additions beyond the seed helper.** The existing test suites for the three services already cover correctness; this story measures performance, not correctness.
+
+### Architecture compliance
+
+- **CLAUDE.md "Bounded SwiftData queries":** The three services already comply. Verifying that compliance via device measurement, not changing it.
+- **CLAUDE.md "No silent `try?`":** The seed helper uses `try` with `do/catch` and logs failures.
+- **CLAUDE.md "Git Workflow":** Branch `feature/15-4-on-device-perf-verification`. Conventional commit `chore(perf): verify history services on-device (Story 15.4)`.
+- **Architecture §Performance (`architecture.md` performance section):** Reaffirms `<500ms` chart render budget. This story is the device-level enforcement.
+
+### Library / framework requirements
+
+- **`os_signpost` / `Logger`:** Apple-shipped, already used elsewhere in the codebase. No new dependency.
+- **Instruments:** Built into Xcode 16.x; no install needed.
+- **Physical iPhone 12+:** External requirement — must be provided by the user (Task 1.1 elicitation).
+
+### File-structure requirements
+
+```
+HyzerKit/Sources/HyzerKit/Domain/SeedHelper.swift                                    [NEW — Task 3.2]
+HyzerApp/Views/Debug/PerfTestSeederView.swift                                        [NEW — Task 3.2, #if DEBUG]
+HyzerApp/ViewModels/PlayerTrendViewModel.swift                                       [EDIT — Task 4.2, optional os_signpost]
+HyzerApp/ViewModels/PersonalBestViewModel.swift                                      [EDIT — Task 5.1, optional os_signpost]
+HyzerApp/ViewModels/HeadToHeadViewModel.swift                                        [EDIT — Task 6.1, optional os_signpost]
+_bmad-output/implementation-artifacts/15-4-evidence/perf.md                          [LOCAL ONLY — Task 7.1, gitignored]
+_bmad-output/implementation-artifacts/13-1-score-trend-visualization-per-player.md   [EDIT — Task 7.2, append-only Completion Note]
+_bmad-output/implementation-artifacts/deferred-work.md                               [EDIT — Task 8.3, replace bullet]
+_bmad-output/implementation-artifacts/sprint-status.yaml                             [EDIT — Task 8.4]
+```
+
+### Testing requirements
+
+- **The seed helper has a one-line correctness test** in `HyzerKitTests/Domain/SeedHelperTests.swift`: `test_seedHelper_creates250Rounds_with18ScoreEventsEach` — asserts the count is exactly 250 + 4500 (250 × 18) after running the seeder. This protects against a regression where the seeder under-seeds and the perf measurement uses a smaller-than-intended fixture.
+- **No tests on the os_signpost wrapping** — signpost emission is unobservable at the unit-test level.
+
+### Previous-story intelligence
+
+**Story 13.1 Completion Note #8 (line 89 in deferred-work.md):** "AC #3 on-device `<500ms` performance measurement — already noted in Completion Note #8. macOS x86 test runner measured ~0.84s for 250 rounds; device target requires on-iPhone measurement during Task 8.2/8.3 manual verification. AC #3 not claimed as fully satisfied until measured."
+
+This is the explicit gate Story 15.4 closes.
+
+**Story 13.2 dev notes (deferred-work line 19):** "`fetchLimit = maxRounds * 20` multiplier under-bounds for multi-course users." This is acknowledged debt — does NOT affect Story 15.4's measurement, but the multiplier IS what determines how much SwiftData work happens. The on-device number this story records is for the CURRENT multiplier; a future optimization story will change the multiplier and re-measure.
+
+**Story 13.3 dev notes (deferred-work line 7):** "Predicate with up to ~10k UUIDs may approach SQLite IN-clause limits." Same caveat — this story measures current behavior, not optimized behavior.
+
+### Latest tech information (2026-05-18)
+
+- **`os_signpost` in Swift 5.5+:** The structured-concurrency-aware API is `Logger.makeSignpostID()` + `beginSignpost(...)` + `endSignpost(...)`. Captured by Instruments without code instrumentation beyond the markers themselves.
+- **Instruments time-profiler accuracy:** ±5ms at the iPhone 14 / iOS 18 level for short-lived signpost intervals. For a 500ms target, ±5ms is acceptable noise.
+- **Release vs. Debug performance gap:** ~2-4× on SwiftData fetches in 2026 (Swift 6 strict concurrency + improved optimizer). MUST measure in Release; Debug-mode numbers are not representative.
+
+### Open questions — pre-answered
+
+**Pre-answered:**
+- Median of 5 → standard methodology for this kind of measurement (per Story 14.2 dev notes implicit acknowledgment; standard mobile-perf practice)
+- Seed harness location → `SeedHelper.swift` in HyzerKit Domain, debug-guarded triggering view in HyzerApp Debug
+- Release-config build → required (per "latest tech information" above)
+- Device floor → iPhone 12+ (per Story 14.2 dev notes)
+- Retain or strip os_signpost → decided in Completion Notes (Task 8.1)
+
+**Still requires elicitation (Task 1.1):**
+- Which physical device is available
+- Test iCloud account preference
+- Whether user can install via Xcode for ~30 min
+
+### Project Structure Notes
+
+This is a measurement + minor-instrumentation story. The committed footprint is modest: one new HyzerKit file, one new HyzerApp file, three viewmodel edits (if instrumentation is retained), and a few doc updates. The evidence (`perf.md`) is gitignored.
+
+### References
+
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:89` — Story 13.1 AC #3 deferral]
+- [Source: `_bmad-output/implementation-artifacts/13-1-score-trend-visualization-per-player.md` — Story 13.1 AC #3 + Completion Note #8 referencing 0.84s simulator measurement]
+- [Source: `HyzerKit/Sources/HyzerKit/Domain/PlayerTrendService.swift` — service being measured]
+- [Source: `HyzerKit/Sources/HyzerKit/Domain/PersonalBestService.swift` — service being baselined]
+- [Source: `HyzerKit/Sources/HyzerKit/Domain/HeadToHeadService.swift` — service being baselined]
+- [Source: `CLAUDE.md` "Project Status" — performance budgets]
+- [Source: `_bmad-output/planning-artifacts/epics-post-mvp.md` PMVP-NFR4 — `<500ms` budget]
+- [Source: `_bmad-output/planning-artifacts/epics-post-mvp.md#Story-15.4` — this story's epic-level scope]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+<!-- Filled by dev agent during execution -->
+
+### Debug Log References
+
+<!-- Filled by dev agent during execution -->
+
+### Completion Notes List
+
+<!-- Filled by dev agent during execution -->
+
+### File List
+
+<!-- Filled by dev agent during execution -->
+
+### Change Log
+
+<!-- Filled by dev agent during execution -->

--- a/_bmad-output/implementation-artifacts/15-5-launch-screen-polish-dark-pin-and-info-plist-consolidation.md
+++ b/_bmad-output/implementation-artifacts/15-5-launch-screen-polish-dark-pin-and-info-plist-consolidation.md
@@ -1,0 +1,243 @@
+# Story 15.5: Launch Screen Polish — `UIUserInterfaceStyle` Pin, Info.plist Consolidation, `LaunchBackground` Light/Dark Variants
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a user launching hyzer-app on a device running iOS in light mode for the first time,
+I want the launch-screen-to-first-frame transition to be visually stable (no flash of light-mode content before the dark UI renders),
+So that the launch impression is consistent with the dark-dominant in-app experience and the first-time-launch perception is polished.
+
+## Acceptance Criteria
+
+1. **Given** the app is installed on a device with iOS system theme set to Light, **when** the app launches cold (force-quit then re-open), **then** no light-mode flash appears between the launch screen and the first SwiftUI frame (Story 9.2 deferral). The transition is visually stable: launch background tone → SwiftUI dark background, with no white/light frame in between. Verified by recording a screen capture and stepping through frames at 30fps; no light frames in the launch→first-frame seam.
+
+2. **Given** `project.yml info.properties` is opened, **when** the `UIUserInterfaceStyle` key is inspected, **then** the value is `Dark` (string). The same value appears in `HyzerApp/App/Info.plist` after `xcodegen generate` runs (XcodeGen merges `project.yml info.properties` into the generated `Info.plist`, so the two stay in sync by construction). Note: Story 9.2 deferred this pin pending "the next launch / first-frame polish pass" — this story IS that pass.
+
+3. **Given** `project.yml` and `HyzerApp/App/Info.plist` are inspected, **when** the five duplicated keys (`UISupportedInterfaceOrientations`, `UIBackgroundModes`, `NSMicrophoneUsageDescription`, `NSSpeechRecognitionUsageDescription`, `ITSAppUsesNonExemptEncryption`) are compared, **then** each key has exactly one source-of-truth declaration in `project.yml info.properties`. After `xcodegen generate`, the resulting `HyzerApp/App/Info.plist` is the XcodeGen-merged output (which may show the keys, but the source-of-truth lives in `project.yml`). The deferred-work bullet explicitly flagged the duplication as not drift-prone in practice but worth consolidating — this AC closes that bullet by making `project.yml` the single editable surface.
+
+4. **Given** `HyzerApp/Resources/Assets.xcassets/LaunchBackground.colorset/Contents.json` is inspected, **when** the `colors` array is read, **then** the array contains at least two entries with appearance modifiers — one for `luminosity: "light"` and one for `luminosity: "dark"`. The dark variant matches `ColorTokens.backgroundPrimary` (read the actual hex from `ColorTokens.swift`; expected `#0A0A0C` per CLAUDE.md design system); the light variant matches the canonical light-mode launch tone (default to `#FFFFFF` if no design-system value exists). The existing universal-only entry is removed or relegated to a fallback under the appearance variants.
+
+5. **Given** the canonical test command (Story 15.2 baseline) is re-run after the Info.plist consolidation, **when** the build completes, **then** the test count matches the Story 15.2 reconciled baseline exactly (the consolidation is a configuration-only edit; no Swift code changes; no test should be affected) and SwiftLint emits zero warnings. If a Swift file unexpectedly changes due to `xcodegen generate` regenerating `project.pbxproj`, that diff is acceptable in the PR but no `.swift` content should be modified.
+
+6. **Given** the launch-screen polish is complete, **when** a fresh Release archive is produced and the embedded `Info.plist` is inspected, **then** the archive carries `UIUserInterfaceStyle = Dark` and the launch screen renders correctly in both light and dark system themes on a physical device (manual verification, evidenced via screen-capture saved at `_bmad-output/implementation-artifacts/15-5-evidence/launch-light.mov` and `launch-dark.mov`).
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Verify pre-state of duplicated keys and LaunchBackground asset** (AC: 2, 3, 4)
+  - [ ] 1.1 Read `project.yml`. Find the `info.properties` section (per current state, lines ~43-62). Note which of the five keys (`UISupportedInterfaceOrientations`, `UIBackgroundModes`, `NSMicrophoneUsageDescription`, `NSSpeechRecognitionUsageDescription`, `ITSAppUsesNonExemptEncryption`) appear there. Note whether `UIUserInterfaceStyle` is currently NOT set (expected per deferred-work line 42 — "current behavior is acceptable until a later polish story").
+  - [ ] 1.2 Read `HyzerApp/App/Info.plist`. Find the same five keys. Confirm they appear at top-level (per current state, duplicates of `project.yml`).
+  - [ ] 1.3 Read `HyzerApp/Resources/Assets.xcassets/LaunchBackground.colorset/Contents.json`. Confirm the current state is universal-only (per current state, `idiom: "universal"` with a single dark color value `(0.039, 0.039, 0.047)` ≈ `#0A0A0C`, no light variant).
+  - [ ] 1.4 Read `HyzerKit/Sources/HyzerKit/Design/ColorTokens.swift`. Find the actual hex value of `backgroundPrimary` (expected `#0A0A0C` for dark; light value may be defined or may be absent). If a light value is defined, use it in Task 4; if not, default to `#FFFFFF` per AC #4.
+
+- [ ] **Task 2: Pin `UIUserInterfaceStyle` to Dark in `project.yml`** (AC: 2)
+  - [ ] 2.1 Edit `project.yml info.properties` to add `UIUserInterfaceStyle: Dark`. Place it alphabetically among the other `UI*` keys (consistent with the existing ordering convention in the file).
+  - [ ] 2.2 Run `xcodegen generate`. The generated `HyzerApp.xcodeproj/project.pbxproj` updates to reflect the new key (no manual `.pbxproj` edit needed). The merged `HyzerApp/App/Info.plist` (XcodeGen-generated) will carry the new key.
+  - [ ] 2.3 Verify via `plutil -p HyzerApp/App/Info.plist | grep UIUserInterfaceStyle` — expected output: `"UIUserInterfaceStyle" => "Dark"`. If empty, XcodeGen did not pick up the change — investigate `project.yml` indentation (YAML is space-sensitive).
+
+- [ ] **Task 3: Consolidate Info.plist duplication into `project.yml`** (AC: 3)
+  - [ ] 3.1 For each of the 5 duplicated keys, verify the value in `project.yml info.properties` matches the value in `HyzerApp/App/Info.plist`. If they match, the consolidation is a no-op — `project.yml` already wins on regenerate. If they DIVERGE, surface to the user before resolving (the deferred-work bullet says they don't drift in practice; a divergence would be a regression).
+  - [ ] 3.2 The question is whether to keep the explicit duplicates in `HyzerApp/App/Info.plist` (where they ARE redundant but harmless because XcodeGen merges) or strip them so `project.yml` is the unambiguous source. The deferred-work bullet (line 45) recommends "consolidating to a single source of truth (prefer `project.yml`)." Apply this: remove the 5 keys from `HyzerApp/App/Info.plist` (so it now contains only target-specific keys, not key duplicates). Run `xcodegen generate` and verify `Info.plist` is regenerated with all 5 keys plus `UIUserInterfaceStyle = Dark` from Task 2.
+  - [ ] 3.3 Re-confirm post-state: `project.yml` has all 6 keys (5 original + `UIUserInterfaceStyle`); generated `HyzerApp/App/Info.plist` has all 6 keys; the file's manual-edit area (the parts NOT under `info.properties`) is empty or only contains things XcodeGen does not own.
+
+- [ ] **Task 4: Add light/dark variants to `LaunchBackground.colorset`** (AC: 4)
+  - [ ] 4.1 Edit `HyzerApp/Resources/Assets.xcassets/LaunchBackground.colorset/Contents.json` to replace the single universal entry with two entries:
+    ```json
+    {
+      "colors" : [
+        {
+          "appearances" : [
+            { "appearance" : "luminosity", "value" : "dark" }
+          ],
+          "color" : {
+            "color-space" : "srgb",
+            "components" : {
+              "alpha" : "1.000",
+              "blue" : "0.047",
+              "green" : "0.039",
+              "red" : "0.039"
+            }
+          },
+          "idiom" : "universal"
+        },
+        {
+          "color" : {
+            "color-space" : "srgb",
+            "components" : {
+              "alpha" : "1.000",
+              "blue" : "1.000",
+              "green" : "1.000",
+              "red" : "1.000"
+            }
+          },
+          "idiom" : "universal"
+        }
+      ],
+      "info" : { "author" : "xcode", "version" : 1 }
+    }
+    ```
+    The second entry (no `appearances`) is the fallback for light mode. The first entry overrides for dark mode. If `UIUserInterfaceStyle = Dark` is set (Task 2), the dark variant always renders regardless of system theme — but having both is correct future-proofing and required by Apple's asset catalog conventions.
+  - [ ] 4.2 If `ColorTokens.swift` exposes a light-mode `backgroundPrimary` value, use that hex instead of `#FFFFFF` for the light variant. Match the canonical design.
+
+- [ ] **Task 5: Manual verification — cold launch in light and dark mode** (AC: 1, 6)
+  - [ ] 5.1 Build a debug configuration on a physical iPhone 12+ (or use the simulator if no device available): `xcodebuild -project HyzerApp.xcodeproj -scheme HyzerApp -destination 'platform=iOS Simulator,name=iPhone 17 with Watch' -configuration Debug build` and install.
+  - [ ] 5.2 Set the device/sim to system theme = Light (Settings → Display & Brightness → Light). Force-quit Hyzer. Launch from home screen. Record a 5-second screen capture of the launch sequence using QuickTime Player (or simulator's Cmd-R record). Save as `_bmad-output/implementation-artifacts/15-5-evidence/launch-light.mov` (gitignored).
+  - [ ] 5.3 Step through the recorded frames at 30fps. Confirm: no white/light flash appears between launch screen and first SwiftUI frame. If a flash appears, the `UIUserInterfaceStyle = Dark` pin is not effective OR the launch screen asset is rendering the light variant — re-check Task 2 and Task 4.
+  - [ ] 5.4 Set the device/sim to system theme = Dark. Repeat 5.2/5.3 and save as `launch-dark.mov`. Confirm consistent dark transition.
+
+- [ ] **Task 6: Build a Release archive to confirm the embedded plist** (AC: 6)
+  - [ ] 6.1 Run the canonical Story 9.1 archive command: `xcodebuild -project HyzerApp.xcodeproj -scheme HyzerApp -configuration Release -destination 'generic/platform=iOS' -archivePath build/HyzerApp.xcarchive archive`.
+  - [ ] 6.2 Verify the embedded `Info.plist` carries `UIUserInterfaceStyle = Dark`: `plutil -p build/HyzerApp.xcarchive/Products/Applications/HyzerApp.app/Info.plist | grep UIUserInterfaceStyle`. Expected output: `"UIUserInterfaceStyle" => "Dark"`.
+  - [ ] 6.3 Optionally upload the archive to TestFlight (reuse Story 9.3 Task 5 upload path) for one tester to validate cold-launch behavior on real hardware in both system themes. This step is optional; the simulator/host verification in Task 5 is the primary evidence.
+
+- [ ] **Task 7: Regression check and close** (AC: 5)
+  - [ ] 7.1 Run `swift test --package-path HyzerKit` — expect same count as Story 15.2 baseline.
+  - [ ] 7.2 Run `xcodebuild test ...` if simulator available — same count.
+  - [ ] 7.3 SwiftLint: re-confirm zero warnings.
+  - [ ] 7.4 Stage and commit. Two suggested commits per area: `feat(launch): pin UIUserInterfaceStyle and add LaunchBackground variants` (Tasks 2, 4) and `chore(config): consolidate Info.plist duplicates into project.yml` (Task 3). Alternatively a single combined commit if the scope is small.
+  - [ ] 7.5 Update `_bmad-output/implementation-artifacts/deferred-work.md` — remove the two Story 9.2 bullets covered by this story (lines 42 and 45 referencing `UIUserInterfaceStyle: Dark` pin and Info.plist consolidation).
+  - [ ] 7.6 Update `_bmad-output/implementation-artifacts/sprint-status.yaml` — Story 15.5 → `done`.
+
+## Dev Notes
+
+### Why this story exists
+
+Story 9.2 deferred two related polish items:
+- Pin `UIUserInterfaceStyle: Dark` ("Pick up in the next launch / first-frame polish pass" — deferred-work line 42)
+- Consolidate the 5 duplicated keys between `project.yml` and `Info.plist` (deferred-work line 45)
+
+Both items have the same root cause: the launch-to-first-frame seam was good-enough for the original 6-tester TestFlight scope but is fragile for broader-tester rollout (any tester on iOS light mode would have seen the seam flash). The exploration findings additionally surfaced a third related item not in the deferred-work file: `LaunchBackground.colorset` is universal-only with no light/dark variants (current state: single dark color). Without light/dark variants, the launch background renders the same dark tone regardless of system theme — which is currently "fine" because nothing else in the launch path is light, but combined with the missing `UIUserInterfaceStyle` pin, the seam is fragile.
+
+This story bundles all three into one launch-polish PR.
+
+### Current state — what is already correct (do NOT redo)
+
+- **`HyzerApp/Resources/Assets.xcassets/AppIcon.appiconset/` is complete (Story 9.2)** — does NOT need light/dark variants because app icons live in different rendering contexts.
+- **Existing 5 Info.plist keys all carry correct values.** `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription` are verbatim per Story 9.2 AC1. `UISupportedInterfaceOrientations` is portrait-only per the existing app shell. `UIBackgroundModes` carries CloudKit-related entries. `ITSAppUsesNonExemptEncryption = false` per Story 9.1.
+- **Story 9.2 AC3 explicitly verified** the launch screen uses `ColorTokens.background` — the current `LaunchBackground.colorset` color `(0.039, 0.039, 0.047)` ≈ `#0A0A0C` matches `ColorTokens.backgroundPrimary`. The dark variant in Task 4 should preserve this exact value.
+- **XcodeGen handles the project regeneration cleanly.** `xcodegen generate` is idempotent; running it twice produces the same output.
+
+### What this story changes
+
+| Change | File | Notes |
+|---|---|---|
+| Pin dark mode | `project.yml info.properties` | Add `UIUserInterfaceStyle: Dark` |
+| Remove duplicates | `HyzerApp/App/Info.plist` | Strip the 5 keys (XcodeGen regenerates them from `project.yml`) |
+| Light/dark variants | `HyzerApp/Resources/Assets.xcassets/LaunchBackground.colorset/Contents.json` | Add appearance modifiers |
+| Project regeneration | `HyzerApp.xcodeproj/project.pbxproj` | Auto-regenerated by `xcodegen generate` |
+| Evidence | `_bmad-output/implementation-artifacts/15-5-evidence/launch-light.mov`, `launch-dark.mov` | LOCAL ONLY, gitignored |
+| Cleanup | `_bmad-output/implementation-artifacts/deferred-work.md` | Remove 2 Story 9.2 bullets |
+| Sprint state | `_bmad-output/implementation-artifacts/sprint-status.yaml` | 15.5 → done |
+
+### What this story must NOT touch
+
+- **No Swift source files.** All changes are config / asset.
+- **No new app icons.** Story 9.2 owns icons; they are complete.
+- **No new permission strings.** Story 9.2 owns the existing ones; they are verbatim per PMVP-FR3.
+- **No build configuration changes** beyond what XcodeGen regenerates from `project.yml`. Signing, code-sign-style, MARKETING_VERSION, CURRENT_PROJECT_VERSION are Story 9.1's territory.
+- **No `aps-environment` flip.** Story 15.1 owns that.
+
+### Architecture compliance
+
+- **CLAUDE.md "Design tokens only":** The launch background MUST use `ColorTokens.backgroundPrimary` value (or equivalent) — no hex literals invented; the value comes from the design system. Task 1.4 reads the canonical value from `ColorTokens.swift`.
+- **CLAUDE.md "Git Workflow":** Branch `feature/15-5-launch-screen-polish`. Conventional commits per Task 7.4.
+- **Architecture §Design System:** Pinning `UIUserInterfaceStyle = Dark` is consistent with the dark-dominant design language defined in CLAUDE.md "Design System" section.
+
+### Library / framework requirements
+
+- **No new dependencies.** All work is configuration + asset.
+- **XcodeGen** is already part of the build flow.
+- **Asset catalog appearance variants** are an iOS 13+ feature; the app's iOS 18 minimum easily covers this.
+
+### File-structure requirements
+
+```
+project.yml                                                                       [EDIT — Task 2.1, 3.1, 3.2]
+HyzerApp/App/Info.plist                                                           [EDIT — Task 3.2, remove duplicates]
+HyzerApp.xcodeproj/project.pbxproj                                                [AUTO-REGEN — Tasks 2.2, 3.2 via xcodegen generate]
+HyzerApp/Resources/Assets.xcassets/LaunchBackground.colorset/Contents.json        [EDIT — Task 4.1]
+_bmad-output/implementation-artifacts/15-5-evidence/launch-light.mov              [LOCAL ONLY — Task 5.2, gitignored]
+_bmad-output/implementation-artifacts/15-5-evidence/launch-dark.mov               [LOCAL ONLY — Task 5.4, gitignored]
+_bmad-output/implementation-artifacts/deferred-work.md                            [EDIT — Task 7.5]
+_bmad-output/implementation-artifacts/sprint-status.yaml                          [EDIT — Task 7.6]
+```
+
+Files that must NOT appear in the diff: any Swift source, any test file, any HyzerKit file, AppIcon.appiconset.
+
+### Testing requirements
+
+- **No automated tests.** The launch screen is rendered by the OS before any test code runs; UI tests for launch-screen behavior are notoriously brittle and not standard practice. Verification is manual via the screen-capture videos (Tasks 5.2, 5.4).
+- **Regression check (AC #5):** `swift test --package-path HyzerKit` and `xcodebuild test ...` — count unchanged. SwiftLint zero warnings.
+
+### Previous-story intelligence
+
+**Story 9.2 deferred-work (line 42):** "Pin `UIUserInterfaceStyle: Dark` in `project.yml info.properties` + `HyzerApp/App/Info.plist`. Reason for deferral: current behavior is acceptable until a later polish story. The universal `LaunchBackground.colorset` still wins for the launch screen in light-mode (the near-black launch is preserved); only the launch→first-frame trait-collection seam is fragile. Pick up in the next launch / first-frame polish pass."
+
+This story IS that polish pass.
+
+**Story 9.2 deferred-work (line 45):** "`UISupportedInterfaceOrientations`, `UIBackgroundModes`, `NSMicrophoneUsageDescription`, `NSSpeechRecognitionUsageDescription`, `ITSAppUsesNonExemptEncryption` are duplicated between `project.yml info.properties` and `HyzerApp/App/Info.plist`. XcodeGen merges them so it's not drift-prone in practice, but consolidating to a single source of truth (prefer `project.yml`) is a future-cleanup item."
+
+This story IS that cleanup.
+
+**Story 9.2 AC3:** "The launch screen uses `ColorTokens.background` (no white flash on launch)." Verified at the time, but the verification was on dark-system-theme only. This story extends the verification to light-system-theme.
+
+**Story 14.2 dev notes:** Reference iPhone 12+ as the device floor. Task 5 manual verification uses iPhone 12+.
+
+### Latest tech information (2026-05-18)
+
+- **`UIUserInterfaceStyle = Dark` in Info.plist** pins the app to dark mode regardless of system theme. iOS 13+ supports this.
+- **Asset catalog `appearance: luminosity, value: dark/light`** is the standard way to provide light/dark variants for assets. iOS 13+ supports this.
+- **`xcodegen generate` idempotency**: as of XcodeGen 2.42+, running twice produces identical output. Safe to run after every `project.yml` edit.
+- **`plutil -p`** is the canonical CLI for inspecting plist values. Built into macOS.
+
+### Open questions — pre-answered
+
+**Pre-answered:**
+- `UIUserInterfaceStyle` value → `Dark` (per Story 9.2 deferral text)
+- Single source of truth for Info.plist keys → `project.yml info.properties` (per Story 9.2 deferred-work line 45 recommendation)
+- LaunchBackground dark variant → exact value of `ColorTokens.backgroundPrimary` (`#0A0A0C` per CLAUDE.md design system)
+- LaunchBackground light variant → `#FFFFFF` unless `ColorTokens.swift` defines a light value
+- Evidence format → 5-second screen captures in light and dark system themes
+
+**Still requires elicitation:** none.
+
+### Project Structure Notes
+
+This is a configuration-only story. The committed diff is `project.yml`, `Info.plist`, `Contents.json`, and `project.pbxproj` (auto-regenerated). No Swift code is touched. No tests are added.
+
+### References
+
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:42` — Story 9.2 UIUserInterfaceStyle deferral]
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:45` — Story 9.2 Info.plist consolidation deferral]
+- [Source: `_bmad-output/implementation-artifacts/9-2-privacy-manifest-permission-strings-and-app-icons.md` — Story 9.2 AC3 launch screen verification, Info.plist key origins]
+- [Source: `_bmad-output/implementation-artifacts/9-1-release-build-configuration-and-signing.md` — Archive command, `ITSAppUsesNonExemptEncryption` origin]
+- [Source: `HyzerApp/Resources/Assets.xcassets/LaunchBackground.colorset/Contents.json` — current universal-only state]
+- [Source: `HyzerApp/App/Info.plist` — duplicated keys]
+- [Source: `project.yml info.properties` — source-of-truth for keys post-consolidation]
+- [Source: `HyzerKit/Sources/HyzerKit/Design/ColorTokens.swift` — `backgroundPrimary` value]
+- [Source: `CLAUDE.md` "Design System" — dark-dominant design language]
+- [Source: `_bmad-output/planning-artifacts/epics-post-mvp.md#Story-15.5` — this story's epic-level scope]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+<!-- Filled by dev agent during execution -->
+
+### Debug Log References
+
+<!-- Filled by dev agent during execution -->
+
+### Completion Notes List
+
+<!-- Filled by dev agent during execution -->
+
+### File List
+
+<!-- Filled by dev agent during execution -->
+
+### Change Log
+
+<!-- Filled by dev agent during execution -->

--- a/_bmad-output/implementation-artifacts/15-6-stale-planning-artifact-cleanup.md
+++ b/_bmad-output/implementation-artifacts/15-6-stale-planning-artifact-cleanup.md
@@ -1,0 +1,185 @@
+# Story 15.6: Stale Planning Artifact Cleanup (`ColorTokens.border` Reference Purge & Frozen-Artifact Policy)
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a future contributor reading the planning artifacts to understand outstanding work,
+I want the stale `ColorTokens.border` references in `epics-1-8-retro-2026-04-07.md` and `epics-post-mvp.md` annotated or purged, and a clear written policy on whether retros and planning docs are append-only frozen snapshots or living documents,
+So that the planning-artifact graph reflects post-Story-9.3 reality and a new contributor does not waste a cycle filing duplicate tech-debt resolution work.
+
+## Acceptance Criteria
+
+1. **Given** the user is asked to choose between two artifact-mutability policies — (a) "append-only frozen snapshots" (retros and sign-off planning docs are historical records; corrections are appended as new annotation lines, never rewritten), and (b) "living documents" (retros and planning docs may be edited in place to reflect current truth, with a `Last revised: YYYY-MM-DD` footer) — **when** the choice is recorded, **then** the policy is documented in a single short section in `CLAUDE.md` (or a new file `_bmad-output/planning-artifacts/artifact-policy.md` if the user prefers a separate location), and the policy applies to all future deferred-work cleanup cycles.
+
+2. **Given** `_bmad-output/implementation-artifacts/epics-1-8-retro-2026-04-07.md:97` is opened, **when** the line referencing `ColorTokens.border` is read, **then** the line carries a resolution annotation under the chosen policy: either appended `_Resolved by Story 9.3 — Path A retained. ColorTokens.border defined and documented at HyzerKit/Sources/HyzerKit/Design/ColorTokens.swift:51. (Story 15.6, 2026-MM-DD)_` (Policy A, append-only) OR rewritten/removed if Policy B (living document) is chosen — in which case the line and any other 9.3-resolved entries are updated to match current truth.
+
+3. **Given** `_bmad-output/planning-artifacts/epics-post-mvp.md` is opened and the three locations referencing `ColorTokens.border` are read (lines 81, 120, 156 per Story 9.3 review-findings), **when** each location is inspected, **then** each carries the same annotation pattern from AC #2 (Policy A — append-only) OR is rewritten/removed (Policy B). Each annotation is identical in wording for consistency.
+
+4. **Given** the canonical regression check (`swift test --package-path HyzerKit` + simulator run if available) is performed after the cleanup, **when** the test count is read, **then** the count matches the Story 15.2 reconciled baseline (no Swift edits — this is doc-only work).
+
+5. **Given** the cleanup is complete, **when** `_bmad-output/implementation-artifacts/deferred-work.md` is read, **then** the two Story 9.3-deferred bullets covered by this story (lines 57-58 referencing stale retro entry and stale epic narrative) are removed.
+
+6. **Given** a new contributor reads `CLAUDE.md` or the `artifact-policy.md` file, **when** they encounter the policy section, **then** the section answers the practical question: "If I find an outdated statement in a retro or sign-off planning doc, what do I do?" The answer is unambiguous — annotate (Policy A) or revise (Policy B) — and includes a one-line rationale for the choice.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: User elicitation — Policy A vs. Policy B** (AC: 1)
+  - [ ] 1.1 Before any edits, **ask the user** the policy question: "Should retros and sign-off planning docs be (a) append-only frozen snapshots — corrections go in as annotation lines that reference resolving stories without rewriting history, OR (b) living documents — content may be rewritten in place to reflect current truth, with a `Last revised: YYYY-MM-DD` footer at the top?" Default recommendation: **Policy A (append-only)**, because (i) retros document a point-in-time team consensus that is valuable as a historical record even after parts are resolved, (ii) sign-off planning docs are referenced by other artifacts (other stories, GitHub issues, retros) and rewriting them creates broken-reference risk, (iii) Policy A is the convention used in software engineering RFC archives (IETF, Python PEPs, OpenJDK JEPs) and is well-understood.
+  - [ ] 1.2 Record the user's choice. If Policy B is chosen, prepare to do the rewriting in Tasks 2-3; if Policy A (recommended), prepare the annotation lines.
+  - [ ] 1.3 If the user wants a hybrid policy (e.g., retros = frozen, planning docs = living), document the distinction in the policy section and apply accordingly. The recommended pure-Policy-A path is simpler and is what these tasks assume.
+
+- [ ] **Task 2: Document the policy** (AC: 1, 6)
+  - [ ] 2.1 If the user chooses Policy A, add a new section to `CLAUDE.md` (likely under "BMAD Project Management"). The section title: `### Frozen Artifact Policy`. Body (one paragraph + one bullet list):
+    > Retrospectives and sign-off planning artifacts (e.g., `_bmad-output/implementation-artifacts/epics-*-retro-*.md`, `_bmad-output/planning-artifacts/epics*.md`, `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`) are **append-only historical snapshots**. They document a point-in-time team consensus. When you find an outdated claim in one of these documents:
+    >
+    > - Append a single italicized annotation line under the outdated claim referencing the resolving story (format: `_Resolved by Story X.Y — <one-line summary>. (Story <cleanup-story>, YYYY-MM-DD)_`).
+    > - Do NOT rewrite the original text or remove the outdated claim.
+    > - Story files themselves (`_bmad-output/implementation-artifacts/<n>-<m>-*.md`) and `sprint-status.yaml` are NOT frozen — they are status records that should reflect current reality.
+    >
+    > The intent: preserve the historical record AND surface current truth via cross-references, without destructive edits.
+  - [ ] 2.2 If the user chooses Policy B, document it analogously: living documents may be rewritten in place; add a `Last revised: YYYY-MM-DD by Story X.Y` line at the top of each rewritten doc; commit message must reference the rewriting cleanup story.
+  - [ ] 2.3 If a hybrid is chosen, document the per-file-type rule clearly.
+
+- [ ] **Task 3: Apply the policy to the three known stale references** (AC: 2, 3)
+  - [ ] 3.1 Open `_bmad-output/implementation-artifacts/epics-1-8-retro-2026-04-07.md`. Locate line 97 (per Story 9.3 review-findings: "`epics-1-8-retro-2026-04-07.md:97` still lists `ColorTokens.border` as open debt"). Under Policy A, append an annotation line immediately below the existing line:
+    `_Resolved by Story 9.3 — Path A retained. ColorTokens.border defined and documented at HyzerKit/Sources/HyzerKit/Design/ColorTokens.swift:51. (Story 15.6, 2026-MM-DD)_`
+    Replace `2026-MM-DD` with the actual story-close date. Under Policy B, edit the line itself to remove the open-debt claim and reflect the resolved state.
+  - [ ] 3.2 Open `_bmad-output/planning-artifacts/epics-post-mvp.md`. Locate the three references (lines 81, 120, 156 per Story 9.3 review-findings — first verify these line numbers are still correct given the Epic 15 additions from this current cycle). Apply the same annotation pattern at each location. The three annotations should be word-identical for consistency.
+  - [ ] 3.3 Run `grep -n "ColorTokens\.border\|Color\.border\b" _bmad-output/implementation-artifacts/epics-1-8-retro-2026-04-07.md _bmad-output/planning-artifacts/epics-post-mvp.md`. Expected output: 4 matches (1 in retro + 3 in epics-post-mvp), each with an adjacent annotation line (Policy A) or replaced text (Policy B). No bare unmarked references remain.
+
+- [ ] **Task 4: Regression check** (AC: 4)
+  - [ ] 4.1 Run `swift test --package-path HyzerKit`. Expect the same count as Story 15.2's reconciled baseline. No Swift was edited; the count must be identical.
+  - [ ] 4.2 Run `xcodebuild test ...` if simulator available — same count.
+  - [ ] 4.3 Run `swiftlint lint`. Expected: zero warnings (no Swift was edited).
+
+- [ ] **Task 5: Update deferred-work and close** (AC: 5)
+  - [ ] 5.1 Remove the two Story 9.3-deferred bullets from `_bmad-output/implementation-artifacts/deferred-work.md` (currently lines 57-58 referencing stale retro entry and stale epic narrative). The bullets are now closed by this story.
+  - [ ] 5.2 Stage and commit. The commit message under Policy A: `chore(docs): annotate resolved ColorTokens.border references + establish frozen-artifact policy (Story 15.6)`. Under Policy B: `docs: rewrite stale ColorTokens.border references and establish living-document policy (Story 15.6)`.
+  - [ ] 5.3 Update `_bmad-output/implementation-artifacts/sprint-status.yaml` — Story 15.6 → `done`.
+
+## Dev Notes
+
+### Why this story exists
+
+Story 9.3 closed `ColorTokens.border` tech debt via Path A (keep + document). The token is now defined and doc-commented at `HyzerKit/Sources/HyzerKit/Design/ColorTokens.swift:51`. Yet four references across two planning artifacts (`epics-1-8-retro-2026-04-07.md:97` and `epics-post-mvp.md:81, 120, 156`) still describe the token as open debt. Story 9.3's review found this but deferred it because the team had not agreed on whether retros and sign-off planning docs are append-only or living.
+
+This story forces that policy decision — it is small enough to be a one-PR story that produces both the policy and the immediate cleanup. Future deferred-work cycles will know what to do without re-debating.
+
+The work is doc-only. Zero Swift. Zero test additions. The risk profile is low; the value is preventing duplicated effort in the future.
+
+### Current state — what is already correct (do NOT redo)
+
+- **`ColorTokens.border` IS resolved at the code level.** Story 9.3 Task 4.2 (Path A) added the doc comment. The token is defined and available; CLAUDE.md's "Known Technical Debt" entry was removed (Story 9.3 Task 4.4).
+- **The four planning-artifact references are stale**, not wrong-at-original-writing-time. At the time those documents were written (April 7 retro; pre-Story-9.3 epics-post-mvp), the token WAS open debt. Story 9.3 changed the truth; the docs didn't auto-update.
+- **No other tech-debt items have this stale-reference profile** as of 2026-05-18. The `ValueCollector` extraction (Story 15.7) is still genuinely open; same for `Task.sleep` flaky timing (Story 15.8). Don't expand scope into those.
+
+### What this story changes
+
+| Change | File | Notes |
+|---|---|---|
+| Add policy section | `CLAUDE.md` | New `### Frozen Artifact Policy` (Policy A) or analogous |
+| Annotate retro | `_bmad-output/implementation-artifacts/epics-1-8-retro-2026-04-07.md` | Append annotation at line 97 |
+| Annotate epics-post-mvp | `_bmad-output/planning-artifacts/epics-post-mvp.md` | Append annotations at lines 81, 120, 156 (re-verify line numbers post-Epic-15 additions) |
+| Remove deferred bullets | `_bmad-output/implementation-artifacts/deferred-work.md` | Remove lines 57-58 |
+| Sprint state | `_bmad-output/implementation-artifacts/sprint-status.yaml` | 15.6 → done |
+
+Tiny diff; explicit policy decision.
+
+### What this story must NOT touch
+
+- **No Swift source.** Doc-only.
+- **No new test files.**
+- **No other tech-debt items.** Stay focused on the four `ColorTokens.border` references.
+- **No rewriting of unrelated content** in the retro or planning docs, even if you notice other staleness in passing.
+
+### Architecture compliance
+
+- **CLAUDE.md "Git Workflow":** Branch `feature/15-6-stale-artifact-cleanup`. Conventional commit per Task 5.2.
+- **CLAUDE.md "BMAD Project Management":** Story 15.6 adds the missing policy section. Aligns the documentation surface to the actual practice.
+
+### Library / framework requirements
+
+- **No new dependencies.** Doc-only work.
+
+### File-structure requirements
+
+```
+CLAUDE.md                                                                            [EDIT — Task 2.1, add policy section]
+_bmad-output/implementation-artifacts/epics-1-8-retro-2026-04-07.md                  [EDIT — Task 3.1, annotation at line 97]
+_bmad-output/planning-artifacts/epics-post-mvp.md                                    [EDIT — Task 3.2, annotations at 3 lines]
+_bmad-output/implementation-artifacts/deferred-work.md                               [EDIT — Task 5.1, remove 2 bullets]
+_bmad-output/implementation-artifacts/sprint-status.yaml                             [EDIT — Task 5.3]
+```
+
+Files that must NOT appear in the diff: any Swift source, any test file, `ColorTokens.swift` (Story 9.3 already touched it), `prd.md`, `architecture.md` (no staleness mentioned in those for this cycle).
+
+### Testing requirements
+
+- **No automated tests added.** Doc-only.
+- **Regression check (AC #4):** Same count as Story 15.2 baseline, zero SwiftLint warnings.
+
+### Previous-story intelligence
+
+**Story 9.3 review-findings (Story 9.3 file, lines 332-334):**
+> [Review][Defer] Stale retro entry — `epics-1-8-retro-2026-04-07.md:97` still lists `ColorTokens.border` as open debt — deferred, pre-existing. Retros are historical snapshots; needs explicit "frozen" policy decision rather than ad-hoc patching.
+> [Review][Defer] Stale epic narrative — `epics-post-mvp.md:81, 120, 156` still describes border token as an open blocker — deferred, pre-existing. Planning artifacts are typically frozen at sign-off; surface for policy decision.
+
+Story 15.6 IS the policy decision that closes these deferrals.
+
+**Story 9.3 dev notes (lines 99-100):** "Story 9.3 is the **first user-visible deliverable** of Epic 9... It also resolves the **last unresolved tech-debt item from the Epics 1–8 retrospective** by either confirming or removing `ColorTokens.border`, completing the 'stabilization phase' framing in CLAUDE.md 'Project Status'."
+
+Story 9.3 was AS clear as it could be that the resolution was complete. The staleness in the retros + planning docs is purely a documentation-hygiene issue.
+
+### Latest tech information
+
+- **The Internet's convention for historical-doc treatment is overwhelmingly Policy A (append-only).** IETF RFCs, Python PEPs, OpenJDK JEPs, ECMAScript proposals — all retain the historical text and add `Updated by RFC YYYY` notes rather than rewriting. The pattern is so ubiquitous that adopting it for this project requires only a one-paragraph policy section.
+- **The alternative (Policy B, living docs) is common in wiki-style knowledge bases** (Notion, Confluence, MediaWiki) but those have version-history infrastructure that BMAD/git does not directly surface in story files.
+
+### Open questions — pre-answered
+
+**Requires elicitation (Task 1.1):**
+- Policy choice: A (append-only, recommended), B (living docs), or hybrid (per-file-type).
+
+**Pre-answered:**
+- Annotation format → `_Resolved by Story X.Y — <one-line summary>. (Story <cleanup-story>, YYYY-MM-DD)_` (italicized, single line)
+- Policy section location → `CLAUDE.md` (default) or `_bmad-output/planning-artifacts/artifact-policy.md` (alternative, user-chooseable)
+- Scope → only the 4 `ColorTokens.border` references. No scope creep into other stale items.
+
+### Project Structure Notes
+
+This is a documentation-policy story. The committed footprint is minimal: one CLAUDE.md edit (or a new `artifact-policy.md`), one retro annotation, three epics-post-mvp annotations, one deferred-work.md edit, one sprint-status.yaml edit. Acceptance is the policy decision being recorded and the four references annotated.
+
+### References
+
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:57-58` — Story 9.3 review deferrals]
+- [Source: `_bmad-output/implementation-artifacts/9-3-app-store-connect-record-testflight-test-group-and-border-token-debt.md:332-334` — Story 9.3 review-finding text]
+- [Source: `_bmad-output/implementation-artifacts/epics-1-8-retro-2026-04-07.md:97` — stale retro reference (Task 3.1)]
+- [Source: `_bmad-output/planning-artifacts/epics-post-mvp.md:81, 120, 156` — stale planning references (Task 3.2)]
+- [Source: `HyzerKit/Sources/HyzerKit/Design/ColorTokens.swift:51` — current resolved state of `ColorTokens.border`]
+- [Source: `CLAUDE.md` "BMAD Project Management" — adjacent section for new policy block]
+- [Source: `_bmad-output/planning-artifacts/epics-post-mvp.md#Story-15.6` — this story's epic-level scope]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+<!-- Filled by dev agent during execution -->
+
+### Debug Log References
+
+<!-- Filled by dev agent during execution -->
+
+### Completion Notes List
+
+<!-- Filled by dev agent during execution -->
+
+### File List
+
+<!-- Filled by dev agent during execution -->
+
+### Change Log
+
+<!-- Filled by dev agent during execution -->

--- a/_bmad-output/implementation-artifacts/15-7-testsupport-spm-target-shared-test-helpers.md
+++ b/_bmad-output/implementation-artifacts/15-7-testsupport-spm-target-shared-test-helpers.md
@@ -1,0 +1,249 @@
+# Story 15.7: Extract Shared `TestSupport` SPM Target (`ValueCollector`, `MockNotificationService`, `MockNearbyDiscoveryClient`)
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the developer maintaining a test suite that has grown across Stories 12.1, 13.x, 14.1, 14.2,
+I want `ValueCollector`, `MockNotificationService`, and `MockNearbyDiscoveryClient` consolidated into a single `HyzerKit/Tests/TestSupport/` shared target,
+So that the three known duplications called out in CLAUDE.md "Known Technical Debt" and the deferred-work entries from Stories 12.1, 13.2, 14.1 are eliminated, and the test suite has one canonical source for each helper.
+
+## Acceptance Criteria
+
+1. **Given** `HyzerKit/Package.swift` is read, **when** the target list is inspected, **then** a new `TestSupport` target exists with `path: "Tests/TestSupport"` and is listed as a test-dependency of `HyzerKitTests`. The HyzerApp side's `HyzerAppTests` target in `project.yml` lists `TestSupport` as a Swift package dependency. The new target compiles cleanly on both iOS and macOS hosts.
+
+2. **Given** `HyzerKit/Tests/TestSupport/Sources/TestSupport/ValueCollector.swift` is created (per SwiftPM target-source-layout convention) AND `MockNotificationService.swift`, `MockNearbyDiscoveryClient.swift` are co-located, **when** the file tree is inspected, **then** the old duplicate locations are deleted in the same commit:
+   - `HyzerKit/Tests/HyzerKitTests/Mocks/MockNotificationService.swift` (deleted)
+   - `HyzerAppTests/Mocks/MockNotificationService.swift` (deleted)
+   - `HyzerKit/Tests/HyzerKitTests/Mocks/MockNearbyDiscoveryClient.swift` (deleted if it exists; verify the exact path via `find HyzerKit HyzerAppTests -name "Mock*"`)
+   - `HyzerAppTests/Mocks/MockNearbyDiscoveryClient.swift` (deleted)
+   - Any `ValueCollector.swift` duplicate across `HyzerKit/Tests/HyzerKitTests/` and `HyzerAppTests/` (deleted; expected at least 2 copies per CLAUDE.md "Known Technical Debt")
+   The consolidated content is the union of the most-recent versions; semantic differences resolved by picking the most-permissive implementation. Any per-call-site customizations remain — see Task 3 for the merge methodology.
+
+3. **Given** `HyzerKitTests` and `HyzerAppTests` are re-run via the Story 15.2 canonical command, **when** the test count is compared to the Story 15.2 reconciled baseline, **then** the count is identical — no tests added, no tests removed; the same green status. Test files that previously imported `@testable import HyzerKit` and used local-relative paths now `import TestSupport` and consume the shared helpers.
+
+4. **Given** `swiftlint lint` runs after the consolidation, **when** the output is read, **then** zero warnings appear at the existing rule levels — including on the new `TestSupport` source files. The 160-character line limit and 100-line function-body limit apply to the consolidated helpers as well; if a duplicate carried a long line that violates limits, that's a hidden tech-debt item to address in this same story (the consolidation is the right moment to fix it).
+
+5. **Given** a future story adds a new `Mock<Service>` helper or a new `ValueCollector`-style utility, **when** the dev agent reads `CLAUDE.md`, **then** a new line in the "Known Technical Debt" / "Test Infrastructure" section documents `TestSupport` as the canonical location for shared test helpers. The line replaces the existing CLAUDE.md mention of `ValueCollector` duplication (which is now resolved by this story).
+
+6. **Given** the migration is complete, **when** the deferred-work bullets specifically about mock/test-helper duplication are reviewed (Story 12.1 line 65, Story 13.2 line 22, Story 14.1 lines 99, 103), **then** those bullets are removed from `_bmad-output/implementation-artifacts/deferred-work.md` — replaced (if needed) by a single line confirming TestSupport extraction. Story 15.7 closure resolves the entire test-mock-duplication thread.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Inventory existing test helpers and identify duplicates** (AC: 2)
+  - [ ] 1.1 Run `find HyzerKit HyzerAppTests -name "ValueCollector*" -o -name "Mock*.swift"` to enumerate all current helper locations. Expected output: at least 6 files (2× ValueCollector, 2× MockNotificationService, 2× MockNearbyDiscoveryClient).
+  - [ ] 1.2 Read each duplicated pair (e.g., `HyzerKit/Tests/HyzerKitTests/Mocks/MockNotificationService.swift` vs. `HyzerAppTests/Mocks/MockNotificationService.swift`) and compare. Note the differences — likely the iOS-side version has more conformances (UIKit-backed protocols) and the HyzerKit-side version is host-only.
+  - [ ] 1.3 For each duplicated pair, decide the consolidation strategy:
+    - **Identical content:** Pick either copy; consolidate to one in TestSupport.
+    - **Subset/superset:** Pick the superset (more conformances, more methods); consolidate.
+    - **Divergent:** Investigate why. If genuine divergence is required (e.g., one consumer needs a different return value), keep both with disambiguating names (e.g., `MockNotificationService_iOS` vs. `MockNotificationService_HostOnly`). The deferred-work entries do NOT suggest divergence; expected to be subset/superset.
+  - [ ] 1.4 Document the merge decisions in a temporary scratch file or in this story's Completion Notes for traceability.
+
+- [ ] **Task 2: Add the `TestSupport` target to `HyzerKit/Package.swift`** (AC: 1)
+  - [ ] 2.1 Read the current `HyzerKit/Package.swift`. Find the targets array.
+  - [ ] 2.2 Add a new `.target` definition for `TestSupport`:
+    ```swift
+    .target(
+        name: "TestSupport",
+        dependencies: ["HyzerKit"],
+        path: "Tests/TestSupport/Sources/TestSupport",
+        swiftSettings: [
+            .enableUpcomingFeature("StrictConcurrency"),
+            .enableExperimentalFeature("StrictConcurrency"),
+        ]
+    ),
+    ```
+    The target depends on `HyzerKit` because the mocks conform to `HyzerKit` protocols. `SWIFT_STRICT_CONCURRENCY = complete` is enforced project-wide per CLAUDE.md "Concurrency"; mirror it here.
+  - [ ] 2.3 Update `HyzerKitTests` target dependencies to include `TestSupport`:
+    ```swift
+    .testTarget(
+        name: "HyzerKitTests",
+        dependencies: ["HyzerKit", "TestSupport"],
+        path: "Tests/HyzerKitTests"
+    ),
+    ```
+  - [ ] 2.4 Create the directory structure: `mkdir -p HyzerKit/Tests/TestSupport/Sources/TestSupport`. Add a placeholder `.swift` file (e.g., `Marker.swift` with `import Foundation`) so SwiftPM sees the directory; this will be deleted in Task 3 once real files are added.
+  - [ ] 2.5 Run `swift build --package-path HyzerKit` to verify the package compiles. Expected: `Build complete!`. If errors, the most likely cause is incorrect path string — match the directory layout exactly.
+
+- [ ] **Task 3: Migrate helpers to `TestSupport`** (AC: 2, 4)
+  - [ ] 3.1 Move `ValueCollector.swift` (the chosen authoritative copy from Task 1.3) into `HyzerKit/Tests/TestSupport/Sources/TestSupport/`. Mark the type `public` (it was likely `internal`/`fileprivate` when colocated inside a test target; now it must be `public` to cross the SwiftPM module boundary into HyzerKitTests / HyzerAppTests).
+  - [ ] 3.2 Move `MockNotificationService.swift` similarly. Public-ize the type and all its methods/properties. Verify the type still conforms to the protocol it claims (`NotificationService` from HyzerKit) — the import of `HyzerKit` is what makes the protocol visible.
+  - [ ] 3.3 Move `MockNearbyDiscoveryClient.swift` similarly. Public-ize.
+  - [ ] 3.4 Delete the old duplicate files. The git diff for this task is high-touch — many file deletions plus three new files. Be exact about what stays and what goes; do NOT leave both copies in place.
+  - [ ] 3.5 Delete the `Marker.swift` placeholder from Task 2.4.
+
+- [ ] **Task 4: Update test imports** (AC: 3)
+  - [ ] 4.1 Find every test file that currently imports `@testable import HyzerKit` AND references `ValueCollector`, `MockNotificationService`, or `MockNearbyDiscoveryClient` by name. Use `grep -rn "ValueCollector\|MockNotificationService\|MockNearbyDiscoveryClient" HyzerKit/Tests HyzerAppTests`.
+  - [ ] 4.2 In each matching file, add `import TestSupport` after the existing `import` statements. The existing `@testable import HyzerKit` stays — those tests still exercise HyzerKit internals.
+  - [ ] 4.3 Add the iOS-side `HyzerAppTests` dependency on `TestSupport` in `project.yml`. The exact YAML stanza depends on the existing target structure; refer to how HyzerAppTests currently lists its Swift package dependencies. Run `xcodegen generate` after the edit.
+  - [ ] 4.4 Run `swift test --package-path HyzerKit` and confirm same count + green. Then run `xcodebuild test ...` (if simulator available) and confirm same count + green.
+
+- [ ] **Task 5: Update `CLAUDE.md` Known Technical Debt and Test Infrastructure docs** (AC: 5)
+  - [ ] 5.1 Read `CLAUDE.md`'s "Known Technical Debt" section. Remove the bullet `- ValueCollector test helper duplicated across multiple test files — needs extraction to shared utility`. The thread is closed.
+  - [ ] 5.2 Add a new bullet in the same area (or a new "Test Infrastructure" sub-section): `**Shared test helpers** live in HyzerKit/Tests/TestSupport/. New mocks, value-collectors, and similar utilities go there. Both HyzerKitTests and HyzerAppTests depend on this target.`
+  - [ ] 5.3 If CLAUDE.md mentions `MockNotificationService` or `MockNearbyDiscoveryClient` duplication explicitly, remove those too. Otherwise leave well-enough alone.
+
+- [ ] **Task 6: Update deferred-work.md and close** (AC: 6)
+  - [ ] 6.1 Remove from `_bmad-output/implementation-artifacts/deferred-work.md`:
+    - Line 65 (Story 12.1: `MockNotificationService` duplication)
+    - Line 22 (Story 13.2: ValueCollector test-helper extraction debt mention)
+    - Line 99 (Story 14.1: ValueCollector test helper thread)
+    - Line 103 (Story 14.1: mock duplication retroactive append)
+  - [ ] 6.2 Stage and commit. Suggested Conventional Commits split: `feat(tests): extract TestSupport SPM target for shared mocks and ValueCollector (Story 15.7)`. Reference closure of the four deferred-work bullets in the commit body.
+  - [ ] 6.3 Update `_bmad-output/implementation-artifacts/sprint-status.yaml` — Story 15.7 → `done`.
+
+## Dev Notes
+
+### Why this story exists
+
+Across Stories 12.1, 13.2, 13.3, 14.1, 14.2, the same three test helpers keep getting duplicated across `HyzerKit/Tests/HyzerKitTests/Mocks/` and `HyzerAppTests/Mocks/`:
+- `ValueCollector` (a SendableValueCollector-style helper for capturing async-pipeline outputs)
+- `MockNotificationService` (UNUserNotificationCenter mock per Story 12.1)
+- `MockNearbyDiscoveryClient` (MultipeerConnectivity mock per Story 14.1)
+
+CLAUDE.md "Known Technical Debt" calls out `ValueCollector` explicitly. The deferred-work file calls out `MockNotificationService` (Story 12.1 line 65) and `MockNearbyDiscoveryClient` (Story 14.1 lines 99, 103). All three are the same pattern: a test helper exists in a private mocks folder, gets needed by both targets, and gets copy-pasted rather than extracted because no shared TestSupport module exists.
+
+This story creates that module. One-time investment, ongoing payoff.
+
+### Current state — what is already correct (do NOT redo)
+
+- **`HyzerKit/Package.swift` already declares HyzerKit and HyzerKitTests targets.** Adding `TestSupport` is an additive change.
+- **`project.yml` already declares HyzerAppTests target with its dependencies.** Adding `TestSupport` as a dependency is additive.
+- **Existing helpers compile correctly in their current dual-location form.** Tests pass. This story changes WHERE the helpers live, not WHAT they do.
+- **SwiftPM target naming conventions** are consistent — the path `Tests/TestSupport/Sources/TestSupport/` matches SwiftPM's nested-Sources layout. Some teams use flat `Tests/TestSupport/` without the inner `Sources/TestSupport/`; check existing conventions in the repo before deciding. The nested form is what SwiftPM uses by default; the flat form requires explicit `path:` declaration.
+
+### What this story changes
+
+| Change | File / Path | Notes |
+|---|---|---|
+| Add target | `HyzerKit/Package.swift` | New `.target(name: "TestSupport", ...)` |
+| Add test dependency | `HyzerKit/Package.swift` | HyzerKitTests gets `dependencies: ["HyzerKit", "TestSupport"]` |
+| Move ValueCollector | `HyzerKit/Tests/TestSupport/Sources/TestSupport/ValueCollector.swift` | NEW location; types made `public` |
+| Move MockNotificationService | same dir | NEW location; types made `public` |
+| Move MockNearbyDiscoveryClient | same dir | NEW location; types made `public` |
+| Delete duplicates | `HyzerKit/Tests/HyzerKitTests/Mocks/*` and `HyzerAppTests/Mocks/*` | All Mock* and ValueCollector* files |
+| Add `import TestSupport` | every test file using the migrated helpers | ~10-20 files affected |
+| Add HyzerAppTests dependency | `project.yml` | iOS test target depends on TestSupport |
+| Regenerate project | `HyzerApp.xcodeproj/project.pbxproj` | Auto via xcodegen generate |
+| Update CLAUDE.md | "Known Technical Debt" section | Remove ValueCollector bullet, add TestSupport mention |
+| Clean up deferred-work | `_bmad-output/implementation-artifacts/deferred-work.md` | Remove 4 bullets |
+
+### What this story must NOT touch
+
+- **No production code changes.** Only test code is moved.
+- **No new tests added.** This is a refactor, not a new-feature story.
+- **No new helpers added.** Stick to ValueCollector + 2 mocks. If you find a fourth duplicate during the inventory in Task 1.1, surface it and decide with the user whether to include in scope.
+- **No production-API changes to the protocols being mocked.** `NotificationService` and `NearbyDiscoveryClient` protocols stay as they are; only the mock implementations move.
+- **No HyzerWatch test target changes** (if a watch test target exists). The mocks being moved are iOS/host-only.
+
+### Architecture compliance
+
+- **CLAUDE.md "Concurrency":** Swift 6 strict concurrency is enforced. The new TestSupport target must compile under `SWIFT_STRICT_CONCURRENCY = complete`. The mocks are likely already compliant; verify.
+- **CLAUDE.md "No silent `try?`":** Verify on the migrated helpers; any silent `try?` gets a justifying comment.
+- **CLAUDE.md "Git Workflow":** Branch `feature/15-7-testsupport-extraction`. Conventional commit `feat(tests): extract TestSupport SPM target for shared mocks and ValueCollector`.
+- **Architecture §Layer Boundaries:** The new target is iOS/macOS/watchOS-compatible (it's a HyzerKit-side test target). Verify by checking `Package.swift` platforms array.
+
+### Library / framework requirements
+
+- **SwiftPM** — already the build tool for HyzerKit.
+- **XcodeGen** — already manages `HyzerAppTests`. Adding a Swift package dependency to a XcodeGen-managed target uses `dependencies: - package: HyzerKit` syntax. Refer to existing usage in `project.yml`.
+- **No new third-party packages.**
+
+### File-structure requirements
+
+```
+HyzerKit/Package.swift                                                                                    [EDIT — Tasks 2.2, 2.3]
+HyzerKit/Tests/TestSupport/Sources/TestSupport/ValueCollector.swift                                       [NEW — Task 3.1]
+HyzerKit/Tests/TestSupport/Sources/TestSupport/MockNotificationService.swift                              [NEW — Task 3.2]
+HyzerKit/Tests/TestSupport/Sources/TestSupport/MockNearbyDiscoveryClient.swift                            [NEW — Task 3.3]
+HyzerKit/Tests/HyzerKitTests/Mocks/MockNotificationService.swift                                          [DELETE — Task 3.4]
+HyzerKit/Tests/HyzerKitTests/Mocks/MockNearbyDiscoveryClient.swift                                        [DELETE — Task 3.4 if exists]
+HyzerAppTests/Mocks/MockNotificationService.swift                                                         [DELETE — Task 3.4]
+HyzerAppTests/Mocks/MockNearbyDiscoveryClient.swift                                                       [DELETE — Task 3.4]
+<every test file using these helpers — verify via grep>                                                   [EDIT — add `import TestSupport`]
+project.yml                                                                                               [EDIT — Task 4.3, add HyzerAppTests TestSupport dep]
+HyzerApp.xcodeproj/project.pbxproj                                                                        [AUTO-REGEN — via xcodegen generate]
+CLAUDE.md                                                                                                 [EDIT — Task 5.1, 5.2]
+_bmad-output/implementation-artifacts/deferred-work.md                                                    [EDIT — Task 6.1]
+_bmad-output/implementation-artifacts/sprint-status.yaml                                                  [EDIT — Task 6.3]
+```
+
+### Testing requirements
+
+- **No new tests added.** The existing test suites that use the migrated helpers must continue to pass (AC #3).
+- **Regression check:** `swift test --package-path HyzerKit` AND `xcodebuild test ...` (if simulator) — same count as Story 15.2 baseline.
+
+### Previous-story intelligence
+
+**Story 12.1 deferred-work (line 65):** "`MockNotificationService` duplicated across `HyzerAppTests/Mocks/` and `HyzerKit/Tests/HyzerKitTests/Mocks/` — same class name, near-identical shape. Matches the `ValueCollector` shared-test-helper debt called out in CLAUDE.md 'Known Technical Debt'. Pick up alongside the `ValueCollector` extraction into a shared `TestSupport` SPM target."
+
+This is the explicit instruction. Story 15.7 IS the "Pick up alongside" referenced.
+
+**Story 13.2 deferred-work (line 22):** "Test helper `insertRound(... completedAt: Date(timeIntervalSinceNow: -1) ...)` produces near-identical timestamps for sibling inserts in the same test. SortDescriptor on identical `completedAt` can shuffle insertion order non-deterministically. Pre-existing test pattern; audit alongside the `ValueCollector` shared-test-helper extraction debt called out in CLAUDE.md 'Known Technical Debt'."
+
+The `insertRound` audit is NOT in scope for Story 15.7 — only the helper extraction is. The audit-recommendation phrase is what scopes that part for a follow-up story.
+
+**Story 14.1 deferred-work (line 99):** "Tests use `for _ in 0..<20 { await Task.yield() }` and `try? await Task.sleep(for: .milliseconds(20))` to wait for async pipeline propagation — CLAUDE.md known flaky-timing tech debt, authorized by Story 14.1 spec line 390. Needs deterministic-wait helper."
+
+This is Story 15.8's concern, NOT 15.7's. The flaky-timing thread is closed in 15.8.
+
+**Story 14.1 deferred-work (line 103):** "New tech-debt entries discovered during Story 14.1 implementation (mock duplication, flaky timing) were noted in Completion Notes but not appended to this file at PR time — retroactively captured above. Future stories: append in the same PR."
+
+The "mock duplication" half of this bullet is Story 15.7's scope; the "flaky timing" half is Story 15.8's.
+
+### Latest tech information
+
+- **SwiftPM TestSupport target pattern** is well-established in the iOS open-source ecosystem (e.g., `swift-async-algorithms`, `swift-collections`, `swift-foundation` all use this pattern).
+- **XcodeGen Swift package dependencies** are declared via `dependencies: - package: <package-name>` under each target. Existing usage in `project.yml` (the HyzerApp target depends on HyzerKit) is the template.
+- **`public` visibility for test helpers** is required when they cross SwiftPM module boundaries. There is no SwiftPM equivalent of `@testable` for non-test-target dependencies — the helpers must be genuinely `public` in their home module.
+
+### Open questions — pre-answered
+
+**Pre-answered:**
+- Target name → `TestSupport` (per Story 12.1 deferred-work line 65 explicit naming)
+- Target path → `HyzerKit/Tests/TestSupport/Sources/TestSupport/` (SwiftPM nested convention)
+- Visibility → `public` (required for cross-module test access)
+- Strategy for divergent duplicates → pick superset; surface to user only if genuine divergence appears
+- HyzerAppTests integration → via XcodeGen `dependencies: - package: HyzerKit` syntax, target sub-dependency `TestSupport`
+
+**Still requires elicitation:** none — all decisions pre-answered.
+
+### Project Structure Notes
+
+The committed diff is substantial in line count (many small file moves and import additions) but conceptually simple (refactor; no behavior change). The post-state is cleaner: one canonical location for each shared helper.
+
+### References
+
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:65` — Story 12.1 MockNotificationService duplication]
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:22` — Story 13.2 ValueCollector audit reference]
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:99, 103` — Story 14.1 ValueCollector + mock duplication]
+- [Source: `CLAUDE.md` "Known Technical Debt" — ValueCollector duplication thread]
+- [Source: `HyzerKit/Package.swift` — current package declaration; will receive new target]
+- [Source: `project.yml` — current HyzerAppTests target; will receive new Swift package dependency]
+- [Source: `HyzerKit/Tests/HyzerKitTests/Mocks/` — current duplicate location 1]
+- [Source: `HyzerAppTests/Mocks/` — current duplicate location 2]
+- [Source: `_bmad-output/planning-artifacts/epics-post-mvp.md#Story-15.7` — this story's epic-level scope]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+<!-- Filled by dev agent during execution -->
+
+### Debug Log References
+
+<!-- Filled by dev agent during execution -->
+
+### Completion Notes List
+
+<!-- Filled by dev agent during execution -->
+
+### File List
+
+<!-- Filled by dev agent during execution -->
+
+### Change Log
+
+<!-- Filled by dev agent during execution -->

--- a/_bmad-output/implementation-artifacts/15-8-deterministic-wait-test-helper.md
+++ b/_bmad-output/implementation-artifacts/15-8-deterministic-wait-test-helper.md
@@ -1,0 +1,278 @@
+# Story 15.8: Deterministic-Wait Test Helper (`Task.sleep` Replacement)
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the developer triaging flaky CI failures,
+I want a `await waitUntil(_:timeout:)` helper that replaces the `Task.sleep(for: .milliseconds(20))` / `for _ in 0..<20 { await Task.yield() }` flaky-timing patterns in `AppServicesNearbyDiscoveryTests` and `WatchVoiceViewModel`,
+So that the flaky-timing thread called out in CLAUDE.md "Known Technical Debt" closes and the test suite's pass rate is no longer dependent on CI runner load.
+
+## Acceptance Criteria
+
+1. **Given** `HyzerKit/Tests/TestSupport/Sources/TestSupport/WaitUntil.swift` is created (in the same shared target created by Story 15.7), **when** the API is inspected, **then** it exposes:
+   ```swift
+   public func waitUntil(
+       _ condition: @MainActor () async -> Bool,
+       timeout: Duration = .seconds(2),
+       pollInterval: Duration = .milliseconds(10),
+       sourceLocation: Testing.SourceLocation = #_sourceLocation
+   ) async throws
+   ```
+   The helper polls `condition` every `pollInterval` and throws `WaitUntilError.timeout` (a public error type colocated in the same file) when `timeout` elapses without the condition becoming true. Polling is `ContinuousClock`-backed (not `Task.sleep` — `ContinuousClock` is the canonical Swift 5.7+ time abstraction). Swift Testing's `SourceLocation` parameter (auto-defaulted via `#_sourceLocation`) ensures failure messages point at the call-site test, not at WaitUntil.swift.
+
+2. **Given** a test that previously used `Task.sleep(for: .milliseconds(20))` or `for _ in 0..<20 { await Task.yield() }` as a wait primitive is refactored to use `waitUntil`, **when** the test runs under both fast (M1/M2 Mac, low load) and slow (CI runner, high load) conditions, **then** it passes deterministically — the polling backoff is bounded by `timeout` and the condition is checked at most `timeout / pollInterval` times before throwing. The wait time is determined by when the condition becomes true, not by an arbitrary fixed delay.
+
+3. **Given** the known flaky tests are refactored:
+   - `AppServicesNearbyDiscoveryTests.test_handleDiscoveredRound_*` family (Story 14.1 spec lines 366–390 — multiple tests using `for _ in 0..<20 { await Task.yield() }`)
+   - `WatchVoiceViewModel` auto-commit-timer test (Story 14.2 dev notes Debug Log References — "passes when run in isolation" indicates flake)
+   - Any other test exercising async-pipeline-propagation via `Task.sleep` patterns (use `grep -rn "Task.sleep\|Task.yield" HyzerKit/Tests HyzerAppTests` to enumerate)
+   **when** the canonical test command (Story 15.2 baseline) runs **10 times in a row**, **then** every run passes — no flake on any of the previously-flaky tests.
+
+4. **Given** the canonical test command is re-run after the refactor, **when** the test count is compared to the Story 15.2 reconciled baseline (post-Story-15.7), **then** the count is identical — this is a refactor of existing tests, not new tests; no count change. The previously-flaky tests now pass deterministically; counts remain stable.
+
+5. **Given** a future story adds a new async-pipeline test, **when** the dev reads the doc comment on `WaitUntil.swift`, **then** the doc comment explains: (a) why `waitUntil` exists (replacing `Task.sleep`/`Task.yield` flaky patterns), (b) when to use it (testing async propagation, NOT testing rate-limiters or throttle windows — for that, use a controllable clock seam, which is out of scope here), (c) a one-line example usage. The comment is the canonical documentation for the helper; CLAUDE.md "Known Technical Debt" gets a one-line cross-reference removing the old flaky-timing bullet.
+
+6. **Given** the deferred-work cleanup is complete, **when** `_bmad-output/implementation-artifacts/deferred-work.md` is read, **then** the bullets specifically about `Task.sleep` flaky timing are removed (Story 14.1 line 99). The CLAUDE.md "Known Technical Debt" entry referencing `Task.sleep(for: .milliseconds(100))` is removed.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Verify prerequisite (Story 15.7 TestSupport exists)** (AC: 1)
+  - [ ] 1.1 Confirm `HyzerKit/Tests/TestSupport/Sources/TestSupport/` exists and the `TestSupport` target is in `HyzerKit/Package.swift`. If Story 15.7 has not been merged, this story cannot proceed — request Story 15.7 be merged first OR include the TestSupport target creation as an additional Task 0 of this story (NOT recommended — keeps stories independently mergeable).
+  - [ ] 1.2 Run `swift build --package-path HyzerKit` and confirm clean build of the TestSupport target.
+
+- [ ] **Task 2: Implement `waitUntil`** (AC: 1, 5)
+  - [ ] 2.1 Create `HyzerKit/Tests/TestSupport/Sources/TestSupport/WaitUntil.swift`:
+    ```swift
+    import Foundation
+    import Testing
+
+    public enum WaitUntilError: Error, CustomStringConvertible {
+        case timeout(elapsed: Duration, condition: String)
+
+        public var description: String {
+            switch self {
+            case .timeout(let elapsed, let condition):
+                return "waitUntil timed out after \(elapsed) while waiting for: \(condition)"
+            }
+        }
+    }
+
+    /// Polls `condition` every `pollInterval` until it returns true OR `timeout` elapses.
+    ///
+    /// Use this in place of `Task.sleep(for: .milliseconds(N))` or
+    /// `for _ in 0..<N { await Task.yield() }` patterns. Those fixed-delay
+    /// patterns flake under CI runner load; `waitUntil` is bounded by the
+    /// condition becoming true, not by an arbitrary wall-clock duration.
+    ///
+    /// **When to use:** Testing that an async pipeline has propagated a
+    /// state change (e.g., a view-model property update after a service
+    /// call, a publisher fires, a downstream effect runs).
+    ///
+    /// **When NOT to use:** Testing rate limiters or throttle windows.
+    /// Those require a controllable clock seam (e.g., `ContinuousClock`
+    /// injected via dependency) — `waitUntil` polls real wall-clock time
+    /// and cannot fast-forward time. If you find yourself writing
+    /// `waitUntil(... timeout: .seconds(30))` for a throttle test, stop
+    /// and refactor the throttle to accept a clock parameter.
+    ///
+    /// **Example:**
+    /// ```swift
+    /// try await waitUntil(
+    ///     { await sut.discoveredRounds.count == 1 }
+    /// )
+    /// ```
+    public func waitUntil(
+        _ condition: @MainActor () async -> Bool,
+        timeout: Duration = .seconds(2),
+        pollInterval: Duration = .milliseconds(10),
+        conditionDescription: String = "<unspecified>",
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+
+        while clock.now < deadline {
+            if await condition() {
+                return
+            }
+            try await clock.sleep(for: pollInterval)
+        }
+
+        // One final check after deadline — handles the case where
+        // the condition becomes true precisely at the deadline.
+        if await condition() {
+            return
+        }
+
+        throw WaitUntilError.timeout(elapsed: timeout, condition: conditionDescription)
+    }
+    ```
+    The implementation uses `ContinuousClock` for the polling backoff (canonical Swift 5.7+ time API), which is itself a Sendable abstraction over the system clock; it does NOT depend on `Task.sleep` directly — `clock.sleep(for:)` is the structured-concurrency equivalent.
+  - [ ] 2.2 Note the `Testing` framework import is what makes `SourceLocation` and `#_sourceLocation` available — this is the Swift Testing version of XCTest's `XCTFail` source-location-pointer mechanism. Required for accurate failure attribution.
+  - [ ] 2.3 The `condition` closure is `@MainActor` because most viewmodel state lives on MainActor. If a test needs to poll non-MainActor state, the test can wrap the condition body in `await` of an actor-isolated property — `@MainActor` works for the common case.
+
+- [ ] **Task 3: Refactor `AppServicesNearbyDiscoveryTests`** (AC: 3)
+  - [ ] 3.1 Find every occurrence of `for _ in 0..<20 { await Task.yield() }` and `try? await Task.sleep(for: .milliseconds(20))` in `HyzerKitTests/Services/AppServicesNearbyDiscoveryTests.swift` (or wherever the suite lives — `grep -rn` to confirm path). Per Story 14.1 spec line 390, these patterns appear throughout the file.
+  - [ ] 3.2 For each occurrence, identify what state-change the test is waiting for (e.g., `appServices.activeRound == .some(round)`, `appServices.cloudKitClient.fetchCallCount > 0`, etc.). Replace the pattern with `try await waitUntil({ await /* same condition */ })`. Add a descriptive `conditionDescription` parameter if helpful.
+  - [ ] 3.3 Add `import TestSupport` to the test file if not already present.
+  - [ ] 3.4 Run the file's tests 10 times in succession (`for i in {1..10}; do xcodebuild test -only-testing:HyzerKitTests/AppServicesNearbyDiscoveryTests ...; done`). Confirm: all 10 runs pass.
+
+- [ ] **Task 4: Refactor `WatchVoiceViewModel` auto-commit timer test** (AC: 3)
+  - [ ] 4.1 Find the auto-commit timer test (per Story 14.2 dev notes Debug Log References: "WatchVoiceViewModel flaky test in HyzerKit full suite (auto-commit timer)"). Likely in `HyzerKit/Tests/HyzerKitTests/Watch/WatchVoiceViewModelTests.swift` — verify path with `grep -rn "auto.?commit" HyzerKit/Tests`.
+  - [ ] 4.2 The test likely uses a fixed `Task.sleep` to wait for the auto-commit timer to fire. Replace with `waitUntil({ await viewModel.committedScore != nil })` or equivalent.
+  - [ ] 4.3 BUT: if the test is actually testing the timer's *timing* (verifying the timer fires after exactly N seconds), `waitUntil` is the wrong tool — see the doc comment from Task 2.1. In that case, this test needs a controllable-clock refactor; file a follow-up story and skip this refactor for now. Add a NOTE in Completion Notes.
+  - [ ] 4.4 Run the test 10 times to verify deterministic pass.
+
+- [ ] **Task 5: Sweep remaining `Task.sleep` / `Task.yield` test patterns** (AC: 3, 6)
+  - [ ] 5.1 Run `grep -rn "Task\.sleep\|Task\.yield" HyzerKit/Tests HyzerAppTests`. For each match:
+    - If it's a wait-for-state pattern: refactor with `waitUntil` per Task 3.
+    - If it's a deliberate-delay pattern (e.g., testing a debounce window with controllable expectation): leave it but add a comment justifying the fixed delay.
+    - If it's a `Task.sleep` outside test code (e.g., inside `HyzerApp/` production code): NOT in scope — production code can legitimately use `Task.sleep`. Do not touch.
+  - [ ] 5.2 Count the number of refactored sites and the number of justified-delay sites. Record in Completion Notes for traceability.
+
+- [ ] **Task 6: Update CLAUDE.md and deferred-work** (AC: 6)
+  - [ ] 6.1 Remove the bullet `- Task.sleep(for: .milliseconds(100)) flaky timing pattern in tests — replace with deterministic waits` from CLAUDE.md "Known Technical Debt".
+  - [ ] 6.2 Add a one-line replacement: `Deterministic wait helper: use TestSupport.waitUntil for async-pipeline propagation tests; see TestSupport/WaitUntil.swift doc comment for when-to-use vs. when-not-to-use guidance.`
+  - [ ] 6.3 Remove the bullet from `_bmad-output/implementation-artifacts/deferred-work.md` (Story 14.1 line 99 referencing `for _ in 0..<20 { await Task.yield() }` deterministic-wait debt).
+
+- [ ] **Task 7: Final regression and close** (AC: 4)
+  - [ ] 7.1 Run `swift test --package-path HyzerKit` — same count as Story 15.2 baseline.
+  - [ ] 7.2 Run `xcodebuild test ...` 10 times in succession — every run passes.
+  - [ ] 7.3 SwiftLint zero warnings.
+  - [ ] 7.4 Stage and commit: `feat(tests): add waitUntil deterministic-wait helper and migrate flaky tests (Story 15.8)`.
+  - [ ] 7.5 Update `_bmad-output/implementation-artifacts/sprint-status.yaml` — Story 15.8 → `done`.
+
+## Dev Notes
+
+### Why this story exists
+
+CLAUDE.md "Known Technical Debt" explicitly calls out `Task.sleep(for: .milliseconds(100)) flaky timing pattern in tests — replace with deterministic waits`. Story 14.1 spec line 390 acknowledged the same pattern as "authorized debt." Story 14.2 dev notes confirm the `WatchVoiceViewModel` test flakes under CI load. The pattern keeps spreading; this story closes the thread.
+
+The helper is small (~30 lines), well-bounded (test-only, no production impact), and the refactor is mechanical (search-and-replace per usage site). The story has higher line-count impact than logical complexity.
+
+### Current state — what is already correct (do NOT redo)
+
+- **Story 15.7 (prereq) establishes `TestSupport` SPM target.** This story drops `WaitUntil.swift` into the same module — no separate target needed.
+- **Swift Testing's `SourceLocation` mechanism** is the canonical way to thread call-site information through helpers. The `#_sourceLocation` macro auto-captures.
+- **`ContinuousClock`** is the Swift 5.7+ abstraction. Replaces the older `DispatchQueue.asyncAfter` / `Timer`-based patterns.
+- **`Task.sleep` in production code** is acceptable; this story does NOT touch production usage of `Task.sleep`.
+
+### What this story changes
+
+| Change | File | Notes |
+|---|---|---|
+| Add waitUntil helper | `HyzerKit/Tests/TestSupport/Sources/TestSupport/WaitUntil.swift` | NEW, ~30 LOC |
+| Refactor discovery tests | `HyzerKit/Tests/HyzerKitTests/Services/AppServicesNearbyDiscoveryTests.swift` (verify path) | Multiple `Task.yield`/`Task.sleep` sites replaced |
+| Refactor watch voice test | `HyzerKit/Tests/HyzerKitTests/Watch/WatchVoiceViewModelTests.swift` (verify path) | Likely one site; may need controllable-clock follow-up per Task 4.3 |
+| Sweep other patterns | Various test files (Task 5) | Per-site refactor or justified-delay comment |
+| CLAUDE.md update | `CLAUDE.md` "Known Technical Debt" | Remove old bullet, add new pointer |
+| Deferred-work cleanup | `_bmad-output/implementation-artifacts/deferred-work.md` | Remove Story 14.1 line 99 bullet |
+
+### What this story must NOT touch
+
+- **No production code changes.** Test-only.
+- **No new tests added.** Refactor, not new feature.
+- **No `Task.sleep` removal in production code.** Production `Task.sleep` is for legitimate purposes (debouncing, polling external state at intervals, etc.); leave alone.
+- **No controllable-clock refactors.** Per the WaitUntil doc comment, those are a separate concern. If a test needs a controllable clock to test throttling, FILE the follow-up — don't bundle into 15.8.
+
+### Architecture compliance
+
+- **CLAUDE.md "Concurrency":** `ContinuousClock` is the Swift 6 strict-concurrency-compliant time API. Aligned.
+- **CLAUDE.md "Git Workflow":** Branch `feature/15-8-waituntil-helper`. Conventional commit per Task 7.4.
+- **Architecture §Testing:** Swift Testing framework; helpers in TestSupport. This story extends both surfaces.
+
+### Library / framework requirements
+
+- **Swift Testing** — already required by all `@Suite` `@Test` test files; `SourceLocation` import is the new additional surface.
+- **`ContinuousClock`** — built into Swift 5.7+ standard library; no dependency.
+- **No new third-party packages.**
+
+### File-structure requirements
+
+```
+HyzerKit/Tests/TestSupport/Sources/TestSupport/WaitUntil.swift                          [NEW — Task 2.1]
+HyzerKit/Tests/HyzerKitTests/Services/AppServicesNearbyDiscoveryTests.swift             [EDIT — Task 3, refactor multiple sites]
+HyzerKit/Tests/HyzerKitTests/Watch/WatchVoiceViewModelTests.swift                       [EDIT — Task 4, refactor or follow-up]
+<other test files surfaced by Task 5.1 grep>                                            [EDIT — per-site]
+CLAUDE.md                                                                               [EDIT — Task 6.1, 6.2]
+_bmad-output/implementation-artifacts/deferred-work.md                                  [EDIT — Task 6.3]
+_bmad-output/implementation-artifacts/sprint-status.yaml                                [EDIT — Task 7.5]
+```
+
+### Testing requirements
+
+- **One sanity test on the helper itself:** `HyzerKit/Tests/TestSupport/Tests/WaitUntilTests.swift` (if SwiftPM supports nested test targets in the TestSupport module, otherwise add to HyzerKitTests). Tests:
+  - `test_waitUntil_returns_whenConditionBecomesTrueImmediately` — condition initially true; helper returns without sleeping.
+  - `test_waitUntil_returns_whenConditionBecomesTrueAfterSeveralPolls` — condition flips true after 3 polls; helper returns.
+  - `test_waitUntil_throws_whenConditionNeverBecomesTrue` — condition stays false; helper throws `WaitUntilError.timeout` after `timeout` elapses.
+  - `test_waitUntil_respectsPollInterval` — measure that polls happen ~every `pollInterval` (with tolerance, since this IS time-based) — flag as "this test is itself time-based and may flake under CI; if it flakes, mark as `@Suite(.disabled)` and note in Completion Notes."
+  
+  The four tests are the only new tests this story adds (counterbalancing the ones it refactors, so net count is +4).
+
+- **Regression check (AC #4):** Test count after refactor + 4 new helper-self-tests = Story 15.2 baseline + 4. CLAUDE.md "Project Status" gets a +4 nudge; mention in Completion Notes.
+
+### Previous-story intelligence
+
+**CLAUDE.md "Known Technical Debt":** "`Task.sleep(for: .milliseconds(100))` flaky timing pattern in tests — replace with deterministic waits." Explicit instruction. Story 15.8 IS the deterministic-wait extraction.
+
+**Story 14.1 deferred-work (line 99):** "Tests use `for _ in 0..<20 { await Task.yield() }` and `try? await Task.sleep(for: .milliseconds(20))` to wait for async pipeline propagation — CLAUDE.md known flaky-timing tech debt, authorized by Story 14.1 spec line 390. Needs deterministic-wait helper."
+
+**Story 14.2 Debug Log References:** "`WatchVoiceViewModel` flaky test in HyzerKit full suite (auto-commit timer) is pre-existing tech debt (`Task.sleep` timing race, noted in CLAUDE.md). Passes when run in isolation." The flake is acknowledged; Story 15.8 fixes it.
+
+### Latest tech information (2026-05-18)
+
+- **`ContinuousClock` vs. `SuspendingClock`:** `ContinuousClock` does NOT pause when the process is suspended; appropriate for short-lived polling. `SuspendingClock` pauses; appropriate for long-lived waits. For test polling (millisecond-scale), `ContinuousClock` is the right choice.
+- **Swift Testing's `SourceLocation` macro `#_sourceLocation`** is the standard pattern as of swift-testing 0.7+. Auto-captures the call-site for failure-attribution accuracy.
+- **`clock.sleep(for:)`** is the structured-concurrency-aware sleep; it cooperates with task cancellation (cancelling the parent task interrupts the sleep). Better than `try? await Task.sleep(...)`.
+
+### Open questions — pre-answered
+
+**Pre-answered:**
+- Helper name → `waitUntil` (matches industry-standard naming: XCTest's `XCTNSPredicateExpectation`, Quick/Nimble's `waitUntil`)
+- Default timeout → 2 seconds (long enough for any reasonable async propagation on CI; short enough to fail fast on real timeouts)
+- Default poll interval → 10ms (responsive enough that fast conditions don't oversleep; not so tight that the poll loop dominates CPU on slow CI)
+- Clock → `ContinuousClock`
+- Source location → Swift Testing's `SourceLocation`
+
+**Still requires elicitation (Task 4.3):** Whether `WatchVoiceViewModel` test is testing state propagation (refactor with `waitUntil`) or timer timing (file follow-up for controllable-clock seam).
+
+### Project Structure Notes
+
+The committed diff is moderate: one new ~30-LOC helper, ~10-20 line-touches across test files for refactors, four new sanity tests, plus doc updates. Logical complexity is low.
+
+### References
+
+- [Source: `CLAUDE.md` "Known Technical Debt" — `Task.sleep` flaky timing entry]
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:99` — Story 14.1 deterministic-wait deferral]
+- [Source: `_bmad-output/implementation-artifacts/14-2-generative-visual-round-signature-on-summary-card.md:537` — WatchVoiceViewModel flake acknowledgment]
+- [Source: `_bmad-output/implementation-artifacts/14-1-multipeerconnectivity-nearby-active-round-discovery.md` — Story 14.1 spec line 390 referenced; full file]
+- [Source: `HyzerKit/Tests/TestSupport/Sources/TestSupport/` — Story 15.7 created this directory]
+- [Source: `HyzerKit/Tests/HyzerKitTests/Services/AppServicesNearbyDiscoveryTests.swift` (verify path) — primary refactor target]
+- [Source: `HyzerKit/Tests/HyzerKitTests/Watch/WatchVoiceViewModelTests.swift` (verify path) — secondary refactor target]
+- [Source: Swift Standard Library `ContinuousClock` documentation]
+- [Source: `_bmad-output/planning-artifacts/epics-post-mvp.md#Story-15.8` — this story's epic-level scope]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+<!-- Filled by dev agent during execution -->
+
+### Debug Log References
+
+<!-- Filled by dev agent during execution -->
+
+### Completion Notes List
+
+<!-- Filled by dev agent during execution -->
+
+### File List
+
+<!-- Filled by dev agent during execution -->
+
+### Change Log
+
+<!-- Filled by dev agent during execution -->

--- a/_bmad-output/implementation-artifacts/15-9-voiceover-friendly-score-formatter.md
+++ b/_bmad-output/implementation-artifacts/15-9-voiceover-friendly-score-formatter.md
@@ -1,0 +1,292 @@
+# Story 15.9: VoiceOver-Friendly Score Formatter (`"E"` → `"even par"`)
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a VoiceOver user reading a leaderboard, head-to-head record, trend chart, or round summary card,
+I want relative-to-par scores like `"E"`, `"+3"`, `"-1"` announced as `"even par"`, `"three over par"`, `"one under par"`,
+So that the announcements are intelligible — current behavior reads `"E"` as the letter "E" (per Story 13.3 review-findings) which is meaningless to a screen-reader user.
+
+## Acceptance Criteria
+
+1. **Given** a new computed property `verboseScoreFormatter: String` (or equivalent — see Task 1 for naming finalization) is added to `Standing` (or a free function colocated with the existing `Standing.formatScore`), **when** invoked with `relativeToPar == 0`, **then** the output is exactly `"even par"` (Story 13.3 review-findings deferred bullet). The compact visual form `"E"` is unchanged — only the accessibility surface gets the verbose form.
+
+2. **Given** `verboseScoreFormatter` is invoked with positive `relativeToPar` values, **when** the string is read, **then**:
+   - `relativeToPar == 1` returns `"one over par"` (singular)
+   - `relativeToPar == 2` returns `"two over par"`
+   - `relativeToPar == 3` returns `"three over par"`
+   - ... up through `relativeToPar == 20` returning `"twenty over par"`
+   - `relativeToPar == 21+` returns digit form `"21 over par"` (fall back to numeric to avoid an unbounded English-number ladder)
+
+3. **Given** `verboseScoreFormatter` is invoked with negative `relativeToPar` values, **when** the string is read, **then** the same cardinal pattern applies with `"under par"`:
+   - `relativeToPar == -1` returns `"one under par"`
+   - `relativeToPar == -2` returns `"two under par"`
+   - ... through `relativeToPar == -20` returning `"twenty under par"`
+   - `relativeToPar == -21-` returns digit form `"-21 under par"` or `"21 under par"` (decide which reads more naturally — recommend `"21 under par"` without the sign)
+
+4. **Given** a `HeadToHeadView` is rendered with VoiceOver active, **when** the player score cell or any score-displaying element receives focus, **then** the accessibility label uses `verboseScoreFormatter` — never the raw compact form. Verified by manual VoiceOver verification on simulator (capture spoken utterance in Completion Notes).
+
+5. **Given** the live leaderboard pill, expanded leaderboard, round summary card (live and screenshot), `PlayerTrendView`, `PersonalBestView`, and `HistoryRoundCard` are rendered with VoiceOver active, **when** each score-displaying element receives focus, **then** every accessibility label uses `verboseScoreFormatter`. Migrate the existing `accessibilityLabel` call sites in this same story. Visual rendering (the compact `"E"`/`"+3"` form via `formatScore` or its equivalent) is NOT changed.
+
+6. **Given** the canonical test command runs after the migration, **when** the test count is compared to the Story 15.2 reconciled baseline, **then** the count increases by exactly the number of new unit tests for `verboseScoreFormatter` (expected: 8 new tests covering even par, ±1, ±2, ±20, ±21, mid-range positive, mid-range negative). Existing tests pass without modification — the `accessibilityLabel` changes are not directly asserted by unit tests (they would be by UI tests, which are not in scope per CLAUDE.md "Testing Standards").
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Decide naming and placement** (AC: 1)
+  - [ ] 1.1 Read `HyzerKit/Sources/HyzerKit/Domain/Standing.swift` (or wherever `Standing` lives — confirm via `find HyzerKit -name "Standing.swift"`). Find the existing `formatScore` (or equivalent). Note the public API surface.
+  - [ ] 1.2 Decide: add `verboseScoreFormatter` as a computed property on `Standing` OR a free function `verboseScore(relativeToPar:Int) -> String` colocated. Recommended: **free function**, because (a) the formatter doesn't need access to other `Standing` properties, (b) it's reusable for non-Standing contexts (e.g., raw scores from trend chart data points), (c) free functions are more testable in isolation. Place it in `HyzerKit/Sources/HyzerKit/Domain/ScoreFormatter.swift` (new file) or extend an existing formatter file if one exists.
+  - [ ] 1.3 Confirm the choice with the user if there is any ambiguity — minor decisions like this can be made by the dev agent if pre-answered; the recommendation above is pre-answered.
+
+- [ ] **Task 2: Implement `verboseScoreFormatter` (or free function)** (AC: 1, 2, 3)
+  - [ ] 2.1 Create or extend the chosen file. Implementation sketch (free-function form):
+    ```swift
+    /// VoiceOver-friendly verbose form of a relative-to-par score.
+    ///
+    /// Visual form: `formatScore(relativeToPar:)` returns "E" / "+3" / "-1".
+    /// Audio form: `verboseScore(relativeToPar:)` returns "even par" /
+    /// "three over par" / "one under par".
+    ///
+    /// Use this for `accessibilityLabel` and any other surface that will be
+    /// read by a screen reader. The compact form is unchanged for visual display.
+    public func verboseScore(relativeToPar: Int) -> String {
+        if relativeToPar == 0 {
+            return "even par"
+        }
+
+        let absValue = abs(relativeToPar)
+        let direction = relativeToPar > 0 ? "over" : "under"
+
+        let valueString: String
+        if absValue <= 20 {
+            valueString = cardinalWord(absValue)
+        } else {
+            // Fall back to digit form for unbounded counts to avoid an
+            // English-number ladder. In practice, +21 / -21 on a single
+            // round of disc golf is rare but possible (terrible round,
+            // par-72 course, score of 93). VoiceOver reads "21" as
+            // "twenty-one" via the system, which is fine.
+            valueString = "\(absValue)"
+        }
+
+        return "\(valueString) \(direction) par"
+    }
+
+    /// 1...20 cardinal English words. Out-of-range values are an
+    /// internal error — the caller must filter.
+    private func cardinalWord(_ n: Int) -> String {
+        precondition(n >= 1 && n <= 20, "cardinalWord supports 1...20")
+        return [
+            "one", "two", "three", "four", "five",
+            "six", "seven", "eight", "nine", "ten",
+            "eleven", "twelve", "thirteen", "fourteen", "fifteen",
+            "sixteen", "seventeen", "eighteen", "nineteen", "twenty"
+        ][n - 1]
+    }
+    ```
+  - [ ] 2.2 If the property-on-`Standing` form was chosen instead, wrap the function in:
+    ```swift
+    extension Standing {
+        public var verboseScoreFormatter: String {
+            verboseScore(relativeToPar: relativeToPar)
+        }
+    }
+    ```
+    (Where `Standing.relativeToPar` is the existing computed field — verify it exists; if it doesn't, the wrap is on `Standing.totalStrokes - Standing.par` or whatever the canonical expression is.)
+  - [ ] 2.3 Add a public visibility annotation. The function must be `public` for HyzerApp to consume from across the SwiftPM module boundary.
+
+- [ ] **Task 3: Unit tests for the formatter** (AC: 1, 2, 3)
+  - [ ] 3.1 Create `HyzerKit/Tests/HyzerKitTests/Domain/ScoreFormatterTests.swift` (or extend existing formatter test file):
+    ```swift
+    import Testing
+    import HyzerKit
+
+    @Suite("verboseScore")
+    struct VerboseScoreTests {
+        @Test func evenPar() {
+            #expect(verboseScore(relativeToPar: 0) == "even par")
+        }
+
+        @Test func oneOver() {
+            #expect(verboseScore(relativeToPar: 1) == "one over par")
+        }
+
+        @Test func oneUnder() {
+            #expect(verboseScore(relativeToPar: -1) == "one under par")
+        }
+
+        @Test func twentyOver() {
+            #expect(verboseScore(relativeToPar: 20) == "twenty over par")
+        }
+
+        @Test func twentyUnder() {
+            #expect(verboseScore(relativeToPar: -20) == "twenty under par")
+        }
+
+        @Test func twentyOneOver_fallsBackToDigits() {
+            #expect(verboseScore(relativeToPar: 21) == "21 over par")
+        }
+
+        @Test func twentyOneUnder_fallsBackToDigits() {
+            #expect(verboseScore(relativeToPar: -21) == "21 under par")
+        }
+
+        @Test func midRangeOver() {
+            #expect(verboseScore(relativeToPar: 7) == "seven over par")
+        }
+    }
+    ```
+    8 tests covering even par, ±1, ±20, ±21 (boundary), and mid-range.
+  - [ ] 3.2 Run `swift test --package-path HyzerKit` — confirm 8 new tests pass.
+
+- [ ] **Task 4: Migrate call sites** (AC: 4, 5)
+  - [ ] 4.1 Find all current `accessibilityLabel(...)` calls that include `Standing.formatScore` or any relative-to-par score expression. Use `grep -rn "accessibilityLabel" HyzerApp/Views` and inspect each match.
+  - [ ] 4.2 For each match where the score is part of the accessibility label, replace the `formatScore` reference with `verboseScore(relativeToPar:)`. Compose the label string to read naturally for VoiceOver. Example:
+    
+    Before:
+    ```swift
+    .accessibilityLabel("\(player.name), \(standing.formatScore), \(standing.totalStrokes) total")
+    ```
+    
+    After:
+    ```swift
+    .accessibilityLabel("\(player.name), \(verboseScore(relativeToPar: standing.relativeToPar)), \(standing.totalStrokes) total")
+    ```
+    
+    The visual rendering elsewhere (the Text view showing `"+3"`) is NOT touched.
+  - [ ] 4.3 Confirm migration in each of the documented surfaces (AC #5 list): HeadToHeadView, leaderboard pill, expanded leaderboard, round summary card (live AND screenshot view), PlayerTrendView, PersonalBestView, HistoryRoundCard. Use `grep -l "Standing\|relativeToPar\|formatScore" HyzerApp/Views/` to enumerate files.
+
+- [ ] **Task 5: Manual VoiceOver verification on simulator** (AC: 4, 5)
+  - [ ] 5.1 Build debug, install on `iPhone 17 with Watch` simulator.
+  - [ ] 5.2 Enable VoiceOver. Navigate to the leaderboard during an active round with at least 3 players with varied scores (one at par, one over, one under). Swipe through each score cell. Capture the spoken utterance verbatim for the at-par player. Confirm `"even par"` (not `"E"`).
+  - [ ] 5.3 Repeat on `HeadToHeadView`, `PlayerTrendView`, `PersonalBestView`, `RoundSummaryView`, and `HistoryRoundCard`. Capture utterances. Record in Completion Notes.
+  - [ ] 5.4 Disable VoiceOver and confirm visual rendering is unchanged — the on-screen score still reads `"E"` / `"+3"`. The visual change would be a regression.
+
+- [ ] **Task 6: Update deferred-work and close** (AC: 6)
+  - [ ] 6.1 Remove from `_bmad-output/implementation-artifacts/deferred-work.md`: the Story 13.3 bullet referencing "`Standing.formatScore`'s `"E"` is pronounced as the letter 'E' by VoiceOver" (line 14).
+  - [ ] 6.2 Update CLAUDE.md if it references this debt anywhere (search for "VoiceOver" and "even par").
+  - [ ] 6.3 Stage and commit: `feat(a11y): add verbose VoiceOver score formatter (Story 15.9)`.
+  - [ ] 6.4 Update `_bmad-output/implementation-artifacts/sprint-status.yaml` — Story 15.9 → `done`.
+
+## Dev Notes
+
+### Why this story exists
+
+Story 13.3 review-findings identified that `Standing.formatScore`'s `"E"` is read by VoiceOver as the letter "E" — meaningless to a screen-reader user. The recommendation was a separate `verboseScoreFormatter`. The same problem exists for `"+3"` (read as "plus three" if read as text, more often read literally as the characters) and `"-1"` (read as "minus one" similar story). CLAUDE.md and the accessibility-first principle make this a launch-relevant fix.
+
+The implementation is straightforward — a single formatter function plus migrations at the call sites. The story is a single PR.
+
+### Current state — what is already correct (do NOT redo)
+
+- **The compact visual form `formatScore` exists and renders correctly.** This story does NOT change it.
+- **`accessibilityLabel` is used throughout score-displaying views** (per Story 13.x and 14.x ACs). The infrastructure for accessibility labels is in place; only the formatter being passed in changes.
+- **CLAUDE.md "Accessibility first" rule** mandates VoiceOver labels for every interactive element. This story extends that to: VoiceOver labels MUST be intelligible, not just present.
+
+### What this story changes
+
+| Change | File | Notes |
+|---|---|---|
+| Add formatter | `HyzerKit/Sources/HyzerKit/Domain/ScoreFormatter.swift` (new) or extend existing | Free function + cardinal helper |
+| Add tests | `HyzerKit/Tests/HyzerKitTests/Domain/ScoreFormatterTests.swift` | 8 tests |
+| Migrate call sites | Various HyzerApp views | accessibilityLabel only; visual unchanged |
+| Deferred-work cleanup | `_bmad-output/implementation-artifacts/deferred-work.md` | Remove Story 13.3 bullet |
+| Sprint state | `_bmad-output/implementation-artifacts/sprint-status.yaml` | 15.9 → done |
+
+### What this story must NOT touch
+
+- **No visual rendering changes.** Only `accessibilityLabel` calls are migrated. The Text views showing "E" / "+3" stay as-is.
+- **No `formatScore` changes.** The compact form remains the same.
+- **No Watch-side changes** (unless the Watch surfaces score VoiceOver labels — verify via `grep` in HyzerWatch; if absent, skip).
+- **No new visual UI for "even par".** This is audio-only.
+
+### Architecture compliance
+
+- **CLAUDE.md "Accessibility first":** This story is the literal accessibility-first enforcement. Every score `accessibilityLabel` now uses the intelligible form.
+- **CLAUDE.md "Design tokens only":** Inapplicable (no UI).
+- **CLAUDE.md "Bounded queries":** Inapplicable (no SwiftData).
+- **CLAUDE.md "No silent `try?`":** No try-anything in this story; pure synchronous formatting.
+- **CLAUDE.md "Git Workflow":** Branch `feature/15-9-verbose-score-formatter`. Conventional commit per Task 6.3.
+
+### Library / framework requirements
+
+- **No new dependencies.** Pure string formatting.
+
+### File-structure requirements
+
+```
+HyzerKit/Sources/HyzerKit/Domain/ScoreFormatter.swift                                   [NEW or extended — Task 2.1]
+HyzerKit/Tests/HyzerKitTests/Domain/ScoreFormatterTests.swift                           [NEW — Task 3.1]
+HyzerApp/Views/Scoring/*.swift                                                          [EDIT — Task 4, accessibilityLabel migrations]
+HyzerApp/Views/History/*.swift                                                          [EDIT — Task 4]
+HyzerApp/Views/Leaderboard/*.swift (verify path)                                        [EDIT — Task 4]
+HyzerApp/Views/Trend/PlayerTrendView.swift (verify path)                                [EDIT — Task 4]
+HyzerApp/Views/HeadToHead/HeadToHeadView.swift (verify path)                            [EDIT — Task 4]
+_bmad-output/implementation-artifacts/deferred-work.md                                  [EDIT — Task 6.1]
+_bmad-output/implementation-artifacts/sprint-status.yaml                                [EDIT — Task 6.4]
+```
+
+### Testing requirements
+
+- **8 new tests** on the formatter itself (Task 3.1) — direct coverage of the new public API.
+- **No UI tests on accessibilityLabel migrations.** UI tests for VoiceOver are out of scope per CLAUDE.md Testing Standards; manual verification (Task 5) is the closing evidence.
+- **Regression check:** Existing tests pass unchanged.
+
+### Previous-story intelligence
+
+**Story 13.3 review-findings (in deferred-work.md line 14):**
+> Standing.formatScore's "E" is pronounced as the letter "E" by VoiceOver in accessibilityLabel for HeadToHeadViewModel — pre-existing tech debt acknowledged in CLAUDE.md. Need a separate verboseScoreFormatter (e.g., "even par") for VoiceOver consumption.
+
+Story 15.9 implements that separate formatter.
+
+**Story 14.2 dev notes (line 526):** Reference `Standing+Formatting.swift`. Verify whether that file exists — if it does, the new `verboseScore` lives there as an extension method, and a separate `ScoreFormatter.swift` is unnecessary.
+
+### Latest tech information
+
+- **VoiceOver pronunciation rules:** iOS VoiceOver reads short uppercase strings (`"E"`, `"AC"`) as the letter(s); longer strings as words. There is no way to override pronunciation for `"E"` other than substituting different text — which is exactly this story's approach.
+- **`accessibilityLabel(_:)`** accepts any string; the system reads it verbatim. No special markup needed.
+
+### Open questions — pre-answered
+
+**Pre-answered:**
+- Function name → `verboseScore(relativeToPar:)` (free function preferred over property; Task 1.2 rationale)
+- Cardinal range → 1–20 in word form; 21+ fall back to digits
+- Negative handling → same cardinal pattern with "under par"; sign dropped for digit fallback ("21 under par", not "-21 under par")
+- Migration scope → only `accessibilityLabel` call sites; no visual changes
+
+**Still requires elicitation:** none.
+
+### Project Structure Notes
+
+The committed diff is moderate: one new HyzerKit file (or extension), one test file, ~5-10 view files with single-line `accessibilityLabel` edits. Logical complexity is low.
+
+### References
+
+- [Source: `_bmad-output/implementation-artifacts/deferred-work.md:14` — Story 13.3 VoiceOver "E" debt]
+- [Source: `HyzerKit/Sources/HyzerKit/Domain/Standing.swift` — existing `formatScore` and `Standing` definition]
+- [Source: `CLAUDE.md` "Accessibility first" rule]
+- [Source: HyzerApp views containing `accessibilityLabel` calls — to be enumerated in Task 4.1]
+- [Source: `_bmad-output/planning-artifacts/epics-post-mvp.md#Story-15.9` — this story's epic-level scope]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+<!-- Filled by dev agent during execution -->
+
+### Debug Log References
+
+<!-- Filled by dev agent during execution -->
+
+### Completion Notes List
+
+<!-- Filled by dev agent during execution -->
+
+### File List
+
+<!-- Filled by dev agent during execution -->
+
+### Change Log
+
+<!-- Filled by dev agent during execution -->

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -162,6 +162,46 @@ stories:
     title: "Generative Visual Round Signature on Summary Card"
     status: done
     epic: 14
+  "15.1":
+    title: "APS Environment Production Flip & App Store Connect Privacy Mirror"
+    status: ready-for-dev
+    epic: 15
+  "15.2":
+    title: "Canonical 407-Test Baseline Pre-Flight Validation on Simulator"
+    status: ready-for-dev
+    epic: 15
+  "15.3":
+    title: "Story 14.2 Generative Signature Ship-Gate Manual Verification"
+    status: ready-for-dev
+    epic: 15
+  "15.4":
+    title: "On-Device History-Services Performance Verification"
+    status: ready-for-dev
+    epic: 15
+  "15.5":
+    title: "Launch Screen Polish — UIUserInterfaceStyle Pin, Info.plist Consolidation, LaunchBackground Light/Dark Variants"
+    status: ready-for-dev
+    epic: 15
+  "15.6":
+    title: "Stale Planning Artifact Cleanup (ColorTokens.border Reference Purge & Frozen-Artifact Policy)"
+    status: ready-for-dev
+    epic: 15
+  "15.7":
+    title: "Extract Shared TestSupport SPM Target (ValueCollector, MockNotificationService, MockNearbyDiscoveryClient)"
+    status: ready-for-dev
+    epic: 15
+  "15.8":
+    title: "Deterministic-Wait Test Helper (Task.sleep Replacement)"
+    status: ready-for-dev
+    epic: 15
+  "15.9":
+    title: "VoiceOver-Friendly Score Formatter (E → even par)"
+    status: ready-for-dev
+    epic: 15
+  "15.10":
+    title: "Centralize History-Service Constants (ScoreEvent.maxEventsPerRound, RoundStatus.completed)"
+    status: ready-for-dev
+    epic: 15
 
 # Parallelization plan for active wave (Epics 10 & 11)
 # Generated 2026-05-14 by Gemini CLI. See dependency analysis: all stories below operate on
@@ -174,6 +214,23 @@ parallel_waves:
     description: "Run after 11.2 merges (shared file: RoundSummaryView.swift)"
     stories: ["11.3"]
     blocked_by: ["11.2"]
+
+# Parallelization plan for Epic 15 (Pre-Launch Hardening)
+# Generated 2026-05-18. Most stories operate on disjoint files; 15.8 has a
+# soft dependency on 15.7 (TestSupport target must exist first). 15.4 has
+# a soft dependency on user-supplied hardware.
+epic_15_waves:
+  wave_1:
+    description: "Fully independent — safe to assign to N parallel dev agents"
+    stories: ["15.1", "15.2", "15.3", "15.5", "15.6", "15.7", "15.9", "15.10"]
+  wave_2:
+    description: "Run after 15.7 merges (TestSupport target must exist)"
+    stories: ["15.8"]
+    blocked_by: ["15.7"]
+  wave_3:
+    description: "Requires physical iPhone 12+ (user elicitation in Task 1.1)"
+    stories: ["15.4"]
+    notes: "Can run in any wave once hardware is available; not blocked by other 15.x stories"
 
 retrospectives:
   "epics-1-8":

--- a/_bmad-output/planning-artifacts/epics-post-mvp.md
+++ b/_bmad-output/planning-artifacts/epics-post-mvp.md
@@ -149,6 +149,12 @@ The most technically novel work: MultipeerConnectivity-based local-network disco
 **PMVP-NFRs covered:** PMVP-NFR2
 **Dependencies:** Epic 9. Soft dependency on Epic 11 (PMVP-FR18 modifies the round summary built there).
 
+### Epic 15: Pre-Launch Hardening
+The remaining deferred work from `_bmad-output/implementation-artifacts/deferred-work.md` that must close before the public/TestFlight push beyond the original `Friends Beta` group. Three categories: App Store submission prep (Story 9.x deferrals — APS environment production flip, App Store Connect privacy mirror, simulator baseline), ship-gate verifications (Story 14.2 manual checks, Story 13.1 on-device perf measurement), and test-infrastructure consolidation (shared `TestSupport` SPM target for `ValueCollector` / mocks / deterministic-wait helper). Closes with two small code-quality items repeatedly flagged in review (VoiceOver "E" pronunciation, magic-multiplier constants).
+**PMVP-FRs covered:** None new — hardens deliverables from Epics 9–14.
+**PMVP-NFRs covered:** Refines PMVP-NFR4 with device-measured evidence.
+**Dependencies:** Epics 9–14 (the surfaces being hardened). All ten stories run independently within the epic.
+
 ---
 
 ## Epic 9: TestFlight Launch Readiness
@@ -646,3 +652,289 @@ So that round summaries feel like keepsakes rather than receipts.
 **Given** the summary card is shared via Story 11.3
 **When** the PNG is exported
 **Then** the signature is included in the exported image (it is part of the screenshot-first design surface)
+
+---
+
+## Epic 15: Pre-Launch Hardening
+
+The remaining deferred work that must close before the public/TestFlight push beyond the original six-friend `Friends Beta` group. Sweeps three categories: (a) **App Store submission prep** items that Story 9.3 explicitly parked until later (APS environment, App Store Connect privacy questionnaire mirror, simulator-baseline test pass), (b) **ship-gate verifications** that prior stories deferred when the dev agent had no simulator/device available (Story 14.2 manual checks, Story 13.1 on-device performance measurement), and (c) **test-infrastructure consolidation** for the three duplication threads called out in CLAUDE.md "Known Technical Debt" (`ValueCollector`, `MockNotificationService`, `MockNearbyDiscoveryClient`, `Task.sleep` flaky timing). Closes with two small code-quality items repeatedly flagged in review (`"E"` VoiceOver pronunciation, magic-multiplier constants in history services).
+
+**Inputs:** `_bmad-output/implementation-artifacts/deferred-work.md` (the authoritative inventory).
+
+**PMVP-FRs covered:** None new — Epic 15 hardens deliverables already shipped in Epics 9–14.
+**PMVP-NFRs covered:** Refines PMVP-NFR4 (chart render <500ms) by adding device-measured evidence.
+**Dependencies:** Epics 9–14 (the surfaces being hardened). No story in Epic 15 depends on any other story within the epic; all ten run independently.
+
+### Story 15.1: APS Environment Production Flip & App Store Connect Privacy Mirror
+
+As the developer preparing to submit hyzer-app for App Store distribution beyond TestFlight,
+I want the production APS environment configured on the App Store-bound entitlements and the App Store Connect Privacy section to mirror the in-bundle `PrivacyInfo.xcprivacy` declarations,
+So that the first App Store submission does not get rejected for an entitlement/manifest mismatch or for an undeclared privacy data type.
+
+**Scope:** Flip `aps-environment` from `development` to `production` in the App Store-bound entitlements path (Story 9.1 deferral; explicitly parked until Epic 12 finalized push delivery, which is now done — Epic 12 closed 2026-05-17); mirror `NSPrivacyCollectedDataTypeUserID` (Linked + AppFunctionality) and `NSPrivacyCollectedDataTypeAudioData` (Not-Linked + AppFunctionality) declarations into App Store Connect's App Privacy questionnaire (Story 9.2 deferral); verify the CloudKit container schema is deployed to Production (Story 9.3 operational flag) so synced rounds work for non-`Friends Beta` testers. No code changes beyond the `.entitlements` flip.
+
+**Acceptance Criteria:**
+
+**Given** `HyzerApp/App/HyzerApp.entitlements` is opened for an App Store-bound distribution build
+**When** the `aps-environment` key is read
+**Then** the value is `production` (Story 9.1 deferral)
+**And** the TestFlight-only build path continues to function (Apple accepts `production` APS in TestFlight; the inverse — `development` for App Store — is the rejection-causing direction)
+
+**Given** the App Store Connect App Privacy section is opened
+**When** the data type list is compared against `HyzerApp/App/PrivacyInfo.xcprivacy`
+**Then** the two are byte-for-intent identical: `User ID` (Linked, non-tracking, AppFunctionality) and `Audio Data` (Not-Linked, non-tracking, AppFunctionality), no extra categories, no missing categories (Story 9.2 deferral)
+
+**Given** the CloudKit Dashboard is opened for container `iCloud.com.shotcowboystyle.hyzerapp`
+**When** the schema deployment state is inspected
+**Then** the Development schema has been promoted to Production (Story 9.3 operational flag) — testers outside the Friends Beta group can sync rounds without the schema-missing silent failure
+
+**Given** a Release archive is produced from the entitlement-flipped main branch
+**When** the archive is uploaded to App Store Connect for TestFlight
+**Then** processing completes without the "Missing Compliance"/entitlement mismatch warning, and the build is `Ready to Test` within 30 minutes
+
+### Story 15.2: Canonical 407-Test Baseline Pre-Flight Validation on Simulator
+
+As the developer about to upload a TestFlight build,
+I want a documented green run of the canonical `xcodebuild test` command against the 407-test baseline on the `iPhone 17 with Watch` simulator,
+So that no regression slips into TestFlight from a sim-unavailable dev-agent run that deferred this gate.
+
+**Scope:** Execute the canonical command from CLAUDE.md "Build & Test Commands" against current `main`, reconcile the test-count baseline (CLAUDE.md states `407 tests`; Story 14.2 Completion Notes report HyzerKit `423` after additions plus 28 HyzerApp suites; Story 9.3 references `278` HyzerKit + simulator deferral — the three figures need a single authoritative reconciliation), and record evidence; no code changes beyond an updated CLAUDE.md test-count snapshot.
+
+**Acceptance Criteria:**
+
+**Given** a clean checkout of current `main` HEAD on a Mac with Xcode 16.x + `iPhone 17 with Watch` simulator installed
+**When** the canonical command `xcodebuild test -project HyzerApp.xcodeproj -scheme HyzerApp -destination 'platform=iOS Simulator,name=iPhone 17 with Watch'` runs
+**Then** the build succeeds, SwiftLint pre-build emits zero warnings, and every test suite passes (Story 9.2 AC7 deferral)
+
+**Given** the test run produces a final count
+**When** the count is compared to CLAUDE.md "Project Status" (`407 tests`)
+**Then** CLAUDE.md is updated to the actual current count with a single sentence noting the breakdown by target (HyzerKit + HyzerAppTests + HyzerWatch test target if any) — the three figures referenced across Stories 9.3 / 14.2 / CLAUDE.md must reconcile to a single number
+
+**Given** the canonical command is unavailable on the dev machine (the recurring sim-unavailable pattern from Stories 9.1, 9.2, 9.3, 14.1)
+**When** the dev agent is unable to run the gate
+**Then** the story stays in `ready-for-dev` and the deferral is explicit — a different reviewer with sim access closes the gate; this story does not get marked `done` based on `swift test --package-path HyzerKit` alone
+
+### Story 15.3: Story 14.2 Generative Signature Ship-Gate Manual Verification
+
+As the developer about to merge Story 14.2 to the launch branch,
+I want a documented manual verification of the four ship-gate items the dev agent could not perform (palette-on-`backgroundElevated` contrast spot-check, AirDrop PNG round-trip, VoiceOver announcement, Reduce Motion behavior),
+So that AC #3 (contrast against `backgroundElevated`), AC #5 (PNG export integrity), AC #6 (VoiceOver), and AC #4 (Reduce Motion) of Story 14.2 are evidenced by human observation, not inferred from code structure.
+
+**Scope:** Perform the four sub-tasks 8.1–8.5 from Story 14.2 on a Mac with simulator support; record any palette-color contrast result below 4.5:1 against `Color.backgroundElevated` (#1C1C1E); record the exported PNG's exact pixel dimensions; record the VoiceOver utterance verbatim; record Reduce Motion behavior. No code changes UNLESS contrast is below threshold — in which case file a single follow-up to swap or constrain the offending palette entry (do not patch in this story; it is a verification story).
+
+**Acceptance Criteria:**
+
+**Given** a debug build running on the `iPhone 17 with Watch` simulator
+**When** a fixture round is completed and the round summary card is shown
+**Then** the signature appears between standings and metadata, uses only the 8-color palette enumerated in Story 14.2 Task 3.1, and the contrast of each palette color against `Color.backgroundElevated` is measured with the Color Contrast Analyzer
+**And** any palette entry that falls below 4.5:1 against `backgroundElevated` is recorded in Completion Notes; a follow-up issue is opened naming the entry and proposing either a replacement token or constraining the entry to outline-only treatment
+
+**Given** the summary card is shared via the "Share Results" button
+**When** the PNG is AirDropped to a Mac (or saved to Notes/Photos)
+**Then** the exported image contains the signature between the standings and metadata regions
+**And** the recorded pixel dimensions reconcile with the documented 120pt × `displayScale` height delta from Story 14.2 AC #5
+
+**Given** VoiceOver is enabled
+**When** the user swipes through the round summary card
+**Then** the signature announces as exactly "Round signature" (Story 14.2 AC #6) — not 32 spoken bytes, not "image", not silent
+
+**Given** Settings → Accessibility → Motion → Reduce Motion is enabled
+**When** a previously-completed round's summary is re-opened from history
+**Then** no animation runs; the final-frame signature is identical to the no-Reduce-Motion render (Story 14.2 AC #4)
+**And** the snapshot-export PNG is identical to the no-Reduce-Motion export
+
+### Story 15.4: On-Device History-Services Performance Verification
+
+As the developer claiming PMVP-NFR4 satisfaction,
+I want the Story 13.1 on-device `<500ms` measurement performed on physical hardware (not a macOS x86 host or a simulator) with 250 rounds, and adjacent device-time measurements for `PersonalBestService.computeBest` and `HeadToHeadService.computeRecord`,
+So that the AC #3 claim of PMVP-NFR4 satisfaction has device-measured evidence and adjacent history services are not silently slower than expected.
+
+**Scope:** Build a release-config Hyzer install onto an iPhone 12+ (Story 14.2 dev notes assume iPhone 12+ as the device floor); seed a fixture player with 250 completed rounds (using a debug-only test-data harness if one exists, otherwise a one-off `xcrun simctl` or device-side seeding script); measure (a) `PlayerTrendService.computeTrend` first-render-to-first-paint via `signpostID`, (b) `PersonalBestService.computeBest` median time over 5 invocations, (c) `HeadToHeadService.computeRecord` median time over 5 invocations; record numbers in `_bmad-output/implementation-artifacts/15-4-evidence/perf.md` (gitignored evidence per Story 9.3's `*-evidence/` glob pattern); no code changes UNLESS a measurement exceeds budget — in which case file a follow-up story.
+
+**Acceptance Criteria:**
+
+**Given** a fixture player with 250 completed rounds is loaded on a physical iPhone 12+ running iOS 18+
+**When** the trend view first appears
+**Then** the time from view-appear to first-paint of the chart is `<500ms` (PMVP-NFR4; Story 13.1 AC #3 unmeasured-on-device deferral)
+**And** the measurement methodology is `os_signpost` `Logger`-based, run 5 times, median reported
+
+**Given** the same fixture player + course (any course with ≥3 completed rounds)
+**When** `PersonalBestService.computeBest` is invoked
+**Then** the median time over 5 invocations is recorded (no formal budget — establishes a baseline number that future regression PRs can compare against)
+
+**Given** the same fixture player + a second player who has played in at least 10 of the 250 rounds
+**When** `HeadToHeadService.computeRecord` is invoked
+**Then** the median time over 5 invocations is recorded — same baseline-only intent as the PB measurement
+
+**Given** any measurement exceeds an obvious-failure threshold (`PlayerTrendService` >500ms, `PersonalBest`/`HeadToHead` >2s as informal regression bars)
+**When** the failure surfaces during verification
+**Then** the failure is recorded in Completion Notes, a follow-up story is filed to optimize the offending service, and Story 15.4 still closes (the verification was performed; the optimization is separate)
+
+### Story 15.5: Launch Screen Polish (`UIUserInterfaceStyle` Pin, Info.plist Consolidation, `LaunchBackground` Light/Dark Variants)
+
+As a user launching hyzer-app on a device running iOS in light mode for the first time,
+I want the launch-screen-to-first-frame transition to be visually stable (no flash of light-mode content before the dark UI renders),
+So that the launch impression is consistent with the dark-dominant in-app experience.
+
+**Scope:** Add `UIUserInterfaceStyle: Dark` to `project.yml info.properties` and `HyzerApp/App/Info.plist` (Story 9.2 deferral); add light/dark variants to `HyzerApp/Resources/Assets.xcassets/LaunchBackground.colorset/` so the launch background is correct under both system themes (current state: universal-only `Contents.json:13`); consolidate the Info.plist duplication between `project.yml` and `HyzerApp/App/Info.plist` for `UISupportedInterfaceOrientations`, `UIBackgroundModes`, `NSMicrophoneUsageDescription`, `NSSpeechRecognitionUsageDescription`, `ITSAppUsesNonExemptEncryption` — `project.yml` is the canonical source of truth, `Info.plist` is XcodeGen-managed (Story 9.2 deferral).
+
+**Acceptance Criteria:**
+
+**Given** the app is installed on a device with iOS system theme set to Light
+**When** the app launches cold
+**Then** no light-mode flash appears between launch screen and first SwiftUI frame (Story 9.2 deferral)
+**And** the launch screen background uses a tone consistent with `ColorTokens.backgroundPrimary` in both light and dark system themes
+
+**Given** `project.yml` and `HyzerApp/App/Info.plist` are inspected
+**When** the five duplicated keys (`UISupportedInterfaceOrientations`, `UIBackgroundModes`, `NSMicrophoneUsageDescription`, `NSSpeechRecognitionUsageDescription`, `ITSAppUsesNonExemptEncryption`) are compared
+**Then** each key has exactly one source-of-truth declaration in `project.yml info.properties`; `HyzerApp/App/Info.plist` either contains no duplicate (XcodeGen-generated from `project.yml`) OR the duplicate is removed and the two files no longer drift on regenerate (Story 9.2 deferral)
+
+**Given** `HyzerApp/Resources/Assets.xcassets/LaunchBackground.colorset/Contents.json` is inspected
+**When** the `colors` array is read
+**Then** the array contains at least two entries — `idiom: "universal"` with `appearances` for `luminosity: "light"` and `luminosity: "dark"` — and the dark variant matches `ColorTokens.backgroundPrimary` (#0A0A0C) while the light variant matches whatever the canonical light-mode launch tone is (treat as #FFFFFF unless the design system has a different `backgroundPrimary` light value)
+
+**Given** the canonical test command is re-run after the Info.plist consolidation
+**When** the build completes
+**Then** the test count remains identical to Story 15.2's reconciled baseline and SwiftLint emits zero warnings
+
+### Story 15.6: Stale Planning Artifact Cleanup (`ColorTokens.border` Reference Purge)
+
+As a future contributor reading the planning artifacts to understand outstanding work,
+I want the `ColorTokens.border` references that remain in `_bmad-output/implementation-artifacts/epics-1-8-retro-2026-04-07.md:97` and `_bmad-output/planning-artifacts/epics-post-mvp.md:81, 120, 156` removed or annotated as resolved,
+So that the planning-artifact graph reflects post-Story-9.3 reality and a new contributor does not file a duplicate tech-debt resolution effort.
+
+**Scope:** Apply the minimal-edit pattern documented in Story 9.3 Review Findings — annotate the three stale planning-artifact references with `(Resolved by Story 9.3 — Path A retained.)` rather than rewriting the artifacts; add a one-paragraph "Frozen Artifact Policy" section to the project's BMAD readme (or `CLAUDE.md`'s "BMAD Project Management" section) defining whether retros and at-sign-off planning docs are append-only historical snapshots or living documents — the policy decision is owned by the user, not the dev agent.
+
+**Acceptance Criteria:**
+
+**Given** `_bmad-output/implementation-artifacts/epics-1-8-retro-2026-04-07.md:97` is read
+**When** the `ColorTokens.border` reference is encountered
+**Then** an inline annotation reads `(Resolved by Story 9.3 — Path A retained. Token is defined and documented at HyzerKit/Sources/HyzerKit/Design/ColorTokens.swift:51.)` or the line is removed entirely per the policy decision
+
+**Given** `_bmad-output/planning-artifacts/epics-post-mvp.md` lines 81, 120, 156 are read
+**When** the three references are encountered
+**Then** each is annotated identically OR removed per the policy decision
+
+**Given** the user is asked to choose between "append-only frozen artifacts" and "living documents" for retros and planning docs
+**When** the decision is recorded
+**Then** the policy is documented in a single short section in CLAUDE.md (or the project README) so the next deferred-work cycle does not re-debate it
+
+**Given** the changes are committed
+**When** the canonical regression check runs
+**Then** no Swift test count changes — this story has no Swift edits
+
+### Story 15.7: Extract Shared TestSupport SPM Target
+
+As the developer maintaining a test suite that has grown across Stories 12.1, 13.x, 14.1, 14.2,
+I want `ValueCollector`, `MockNotificationService`, and `MockNearbyDiscoveryClient` consolidated into a single `HyzerKit/Tests/TestSupport/` shared target,
+So that the three known duplications called out in CLAUDE.md "Known Technical Debt" and the deferred-work entries from Stories 12.1, 13.2, 14.1 are eliminated, and the test suite has one canonical source for each helper.
+
+**Scope:** Create a new `HyzerKit/Tests/TestSupport/` Swift package target (or `target_dependencies` block in `Package.swift`) exposing `ValueCollector`, `MockNotificationService`, `MockNearbyDiscoveryClient`; update `HyzerKitTests` and `HyzerAppTests` to import the shared target; delete the duplicate implementations in `HyzerKit/Tests/HyzerKitTests/Mocks/` and `HyzerAppTests/Mocks/`. No production-code changes; no behavior changes.
+
+**Acceptance Criteria:**
+
+**Given** `HyzerKit/Package.swift` is read
+**When** the target list is inspected
+**Then** a new `TestSupport` target exists with `path: "Tests/TestSupport"` and is listed as a test dependency of `HyzerKitTests`
+**And** the iOS app side's `HyzerAppTests` target in `project.yml` lists `TestSupport` as a Swift package dependency
+
+**Given** `HyzerKit/Tests/TestSupport/ValueCollector.swift`, `MockNotificationService.swift`, and `MockNearbyDiscoveryClient.swift` are created
+**When** the file tree is inspected
+**Then** the old duplicate locations (`HyzerKit/Tests/HyzerKitTests/Mocks/MockNotificationService.swift`, `HyzerAppTests/Mocks/MockNotificationService.swift`, `HyzerAppTests/Mocks/MockNearbyDiscoveryClient.swift`, and any `ValueCollector` duplicates) are deleted in the same commit
+**And** the contents of the consolidated files are the union of the most-recent versions across the duplicates — semantic differences resolved by picking the more-permissive/more-recent implementation
+
+**Given** `HyzerKitTests` and `HyzerAppTests` are re-run
+**When** the test count is compared to the Story 15.2 reconciled baseline
+**Then** the count is identical (no tests added, no tests removed; same green status)
+**And** `swiftlint lint` emits zero warnings on the new `TestSupport` files
+
+**Given** a future story adds a new `Mock<Service>` helper
+**When** the dev agent reads `CLAUDE.md`
+**Then** the existence of `TestSupport` is documented as the canonical location for new shared mocks — the duplication thread is closed
+
+### Story 15.8: Deterministic-Wait Test Helper (`Task.sleep` Replacement)
+
+As the developer triaging flaky CI failures,
+I want a `await waitUntil(_:timeout:)` helper that replaces the `Task.sleep(for: .milliseconds(20))` / `for _ in 0..<20 { await Task.yield() }` flaky-timing patterns in `AppServicesNearbyDiscoveryTests` and `WatchVoiceViewModel`,
+So that the flaky-timing thread called out in CLAUDE.md "Known Technical Debt" closes and the test suite's pass rate is no longer dependent on CI runner load.
+
+**Scope:** Add `HyzerKit/Tests/TestSupport/WaitUntil.swift` (in the same target created by Story 15.7) implementing a polling-with-timeout helper backed by `ContinuousClock`; refactor the call-sites in `AppServicesNearbyDiscoveryTests` (Story 14.1 deferral), `WatchVoiceViewModel` flaky test (Story 14.2 dev notes), and any other test using `Task.sleep` or `Task.yield` loops as wait primitives; do NOT change production code (the `ContinuousClock` seam on `AppServices` is out of scope for this story — its addition is what unlocks Story 14.1's missing throttle-window test, which can then be filed separately).
+
+**Acceptance Criteria:**
+
+**Given** `HyzerKit/Tests/TestSupport/WaitUntil.swift` is read
+**When** the API is inspected
+**Then** it exposes `func waitUntil(_ condition: @MainActor () async -> Bool, timeout: Duration = .seconds(2), pollInterval: Duration = .milliseconds(10), sourceLocation: SourceLocation = #_sourceLocation) async throws` using Swift Testing's `SourceLocation` so failures point at the test, not the helper
+
+**Given** a test using `Task.sleep` is refactored to use `waitUntil`
+**When** the test runs under both fast (M1/M2) and slow (CI runner) conditions
+**Then** it passes deterministically — the polling backoff is bounded by `timeout` and the condition check runs at most `timeout / pollInterval` times before throwing
+
+**Given** the existing flaky tests are refactored: `test_handleDiscoveredRound_throttleWindow_firstCall` and its siblings in `AppServicesNearbyDiscoveryTests` (Story 14.1 spec lines 366–390), the `WatchVoiceViewModel` auto-commit timer test (Story 14.2 dev notes)
+**When** the canonical test command runs 10 times in a row
+**Then** every run passes — no flake on any of the previously-flaky tests
+
+**Given** a future story adds a new async-pipeline test
+**When** the dev reads the test helper documentation in `WaitUntil.swift`'s doc comment
+**Then** they use `waitUntil` rather than re-inventing a `Task.sleep` pattern; the helper's doc comment includes the rationale and a one-line example
+
+### Story 15.9: VoiceOver-Friendly Score Formatter (`"E"` → `"even par"`)
+
+As a VoiceOver user reading a leaderboard, head-to-head, or trend view,
+I want relative-to-par scores like `"E"`, `"+3"`, `"-1"` announced as `"even par"`, `"three over par"`, `"one under par"`,
+So that the announcements are intelligible (current behavior reads `"E"` as the letter "E", which is meaningless and was acknowledged as tech debt in CLAUDE.md and Story 13.3 review findings).
+
+**Scope:** Add `Standing.verboseScoreFormatter: String` (or a free function `verboseScore(relativeToPar:Int) -> String`) producing the spoken form; update `HeadToHeadViewModel`, `PlayerTrendViewModel`, `PersonalBestViewModel`, and any leaderboard/summary VoiceOver `accessibilityLabel` site that currently passes `Standing.formatScore` to read from `verboseScoreFormatter` instead; preserve the existing compact `"E"`/`"+3"` formatter for non-VoiceOver visual rendering — only the accessibility label changes.
+
+**Acceptance Criteria:**
+
+**Given** `Standing.verboseScoreFormatter` is invoked with `relativeToPar == 0`
+**When** the string is read
+**Then** the output is exactly `"even par"` (Story 13.3 deferral)
+
+**Given** `Standing.verboseScoreFormatter` is invoked with `relativeToPar == 1`
+**When** the string is read
+**Then** the output is `"one over par"` — singular form, no plural
+
+**Given** `Standing.verboseScoreFormatter` is invoked with `relativeToPar == -1`
+**When** the string is read
+**Then** the output is `"one under par"` — singular form
+
+**Given** `Standing.verboseScoreFormatter` is invoked with `relativeToPar == 2..=20` (positive) or `-20..=-2` (negative)
+**When** the string is read
+**Then** the output uses cardinal word forms (`"two"`, `"three"`, …, `"twenty"`) + `"over par"`/`"under par"` — integers above 20 fall back to digit form (`"21 over par"`) to avoid an unbounded word ladder
+
+**Given** a `HeadToHeadView` is rendered with VoiceOver active
+**When** the player score cell receives focus
+**Then** the announcement uses `verboseScoreFormatter` — never raw `"E"`, never raw `"+3"`
+
+**Given** the leaderboard and round summary card are rendered with VoiceOver active
+**When** each score row is announced
+**Then** the announcement uses `verboseScoreFormatter` (the existing `accessibilityLabel` call sites are migrated in this same story; no new VoiceOver surfaces are introduced)
+
+### Story 15.10: Centralize History-Service Constants (`maxEventsPerRound`, `RoundStatus.completed`)
+
+As a future contributor refactoring `PlayerTrendService`, `PersonalBestService`, or `HeadToHeadService`,
+I want the `fetchLimit = maxRounds * 20` magic multiplier promoted to a single named constant `ScoreEvent.maxEventsPerRound = 20` and the string-literal predicate `$0.status == "completed"` replaced with a type-safe `RoundStatus.completed` symbol,
+So that future tweaks to scoring-event-cap or round-status comparison do not require three-service touch-points and a manual cross-grep.
+
+**Scope:** Add `static let maxEventsPerRound = 20` to `ScoreEvent`; replace `maxRounds * 20` in `PlayerTrendService`, `PersonalBestService`, `HeadToHeadService` with `maxRounds * ScoreEvent.maxEventsPerRound`; introduce a type-safe `RoundStatus.completed` constant (or extend the existing enum if one exists; CLAUDE.md mentions `Round.lifecycleState` but the deferred-work file references `Round.status == "completed"` string predicates — investigate and reconcile); refactor all three services' predicate string literal to the symbol form. No behavior changes; no test additions beyond a compile-time guard test.
+
+**Acceptance Criteria:**
+
+**Given** `HyzerKit/Sources/HyzerKit/Models/ScoreEvent.swift` is read
+**When** the type is inspected
+**Then** it exposes `public static let maxEventsPerRound: Int = 20` with a one-line doc comment explaining the multiplier's origin (Story 13.x services; per-round upper bound of strokes-plus-corrections per player)
+
+**Given** `PlayerTrendService.swift`, `PersonalBestService.swift`, and `HeadToHeadService.swift` are inspected
+**When** every `fetchLimit` initialization referencing `* 20` is grep'd
+**Then** every match uses `ScoreEvent.maxEventsPerRound` (zero raw `* 20` remaining in the three files)
+**And** the `$0.status == "completed"` string-literal predicate is replaced with the type-safe constant in every match (Story 13.1 deferral)
+
+**Given** the canonical test command runs after the refactor
+**When** the test count is compared to Story 15.2's reconciled baseline
+**Then** every test still passes (the refactor is behavior-preserving)
+
+**Given** a new SwiftData service is added in a future story
+**When** the dev agent reads `CLAUDE.md` or the doc comments on `ScoreEvent.maxEventsPerRound` and `RoundStatus.completed`
+**Then** they reuse the named constants — no new magic multipliers or string literals enter the codebase


### PR DESCRIPTION
## Summary

- Adds **Epic 15: Pre-Launch Hardening** to `epics-post-mvp.md` with 10 stories converting `deferred-work.md` into actionable scope.
- Covers three categories: App Store submission prep (Story 9.x deferrals), ship-gate verifications (Story 13.1 / 14.2 manual checks), and test-infrastructure consolidation (`TestSupport` SPM target, `waitUntil` helper, VoiceOver score formatter, history-service constants).
- Updates `sprint-status.yaml` with 10 new `ready-for-dev` entries plus an `epic_15_waves` parallelization plan.

## Stories created

| # | Title | Closes deferrals from |
|---|---|---|
| 15.1 | APS env production flip & ASC privacy mirror | 9.1, 9.2, 9.3 |
| 15.2 | Canonical test baseline pre-flight validation | 9.2 (recurring sim-unavailable defer) |
| 15.3 | Story 14.2 ship-gate manual verification | 14.2 (Tasks 8.1–8.5, contrast spot-check) |
| 15.4 | On-device history-services perf verification | 13.1 AC #3 |
| 15.5 | Launch screen polish (dark pin, Info.plist consolidation, LaunchBackground variants) | 9.2 |
| 15.6 | Stale planning artifact cleanup + frozen-artifact policy | 9.3 review-findings |
| 15.7 | `TestSupport` SPM target extraction | 12.1, 14.1, CLAUDE.md `ValueCollector` debt |
| 15.8 | Deterministic-wait test helper (`Task.sleep` replacement) | 14.1, CLAUDE.md flaky-timing debt |
| 15.9 | VoiceOver-friendly score formatter (`"E"` → `"even par"`) | 13.3 |
| 15.10 | Centralize `ScoreEvent.maxEventsPerRound` + `RoundStatus.completed` | 13.1, 13.2, 13.3 |

20+ deferred-work items are addressed across the 10 stories.

## Parallelization plan (documented in `sprint-status.yaml` `epic_15_waves`)

- **Wave 1 (6 stories, parallel-safe):** 15.1, 15.3, 15.5, 15.6, 15.9, 15.10
- **Wave 2 (CLAUDE.md merge points):** 15.2, 15.7
- **Wave 3 (hard dep on 15.7):** 15.8
- **Independent (hardware-bound):** 15.4

## Scope boundaries

- No Swift code changes in this PR — it is planning artifacts only.
- Each story's Task 7/8 cleanup section is responsible for purging the corresponding `deferred-work.md` bullets at implementation time.
- Story 9.3 \"frozen artifact policy\" question is forwarded to Story 15.6 for explicit decision (default recommendation: append-only).

## Test plan

- [ ] Reviewer verifies each story file has Status `ready-for-dev` and complete AC + Tasks sections.
- [ ] Reviewer confirms Epic 15 entry in `epics-post-mvp.md` matches story scopes.
- [ ] Reviewer confirms `sprint-status.yaml` has all 10 entries plus `epic_15_waves` block.
- [ ] No Swift / test / config files modified (planning-only PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)