### PR TITLE
fix(ci): add `set -o pipefail` to xcodebuild + swift test steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,9 @@ jobs:
         run: swift package --package-path HyzerKit resolve
 
       - name: Run HyzerKit tests
-        run: swift test --package-path HyzerKit 2>&1 | tee hyzerkit-test-output.txt
+        run: |
+          set -o pipefail
+          swift test --package-path HyzerKit 2>&1 | tee hyzerkit-test-output.txt
 
       - name: Upload test output on failure
         if: failure()
@@ -109,6 +111,7 @@ jobs:
 
       - name: Run HyzerApp tests
         run: |
+          set -o pipefail
           xcodebuild test \
             -project HyzerApp.xcodeproj \
             -scheme HyzerApp \

--- a/HyzerKit/Sources/HyzerKit/Sync/UserDefaultsStorage.swift
+++ b/HyzerKit/Sources/HyzerKit/Sync/UserDefaultsStorage.swift
@@ -7,7 +7,13 @@ public protocol UserDefaultsStorage: Sendable {
     func setString(_ value: String, forKey defaultName: String)
 }
 
-extension UserDefaults: UserDefaultsStorage {
+// `@unchecked Sendable` is required because the `UserDefaultsStorage`
+// protocol declares `Sendable` conformance, but `UserDefaults` is defined
+// in Foundation (a different module) than this extension. Swift 6 strict
+// concurrency requires retroactive `Sendable` conformance on cross-module
+// classes to be opt-in via `@unchecked Sendable`. `UserDefaults` is
+// documented as thread-safe by Apple, so the unchecked opt-in is sound.
+extension UserDefaults: @unchecked Sendable, UserDefaultsStorage {
     public func setString(_ value: String, forKey defaultName: String) {
         set(value, forKey: defaultName)
     }


### PR DESCRIPTION
## Summary

Restores real signal on the GitHub Actions `Tests` workflow by fixing two issues that have been silently masking CI failures.

### Issue 1: Missing `set -o pipefail` (workflow file)

Both test-running steps in `.github/workflows/test.yml` pipe stdout through `tee` for log capture but did not set `pipefail`. Bash pipes return the last-stage exit code by default, so a failing `xcodebuild test` or `swift test` returns `tee`'s exit code (0) and the GitHub Actions step reports `pass` regardless.

### Issue 2: Swift 6 strict-conformance error in HyzerKit (revealed by Issue 1 fix)

After adding `set -o pipefail`, CI surfaced a pre-existing compilation error that Issue 1 had been hiding:

> `UserDefaultsStorage.swift:10: error: conformance to 'Sendable' must occur in the same source file as class 'UserDefaults'; use '@unchecked Sendable' for retroactive conformance`

`UserDefaultsStorage` protocol declares `Sendable`; `extension UserDefaults: UserDefaultsStorage` retroactively conforms `UserDefaults` (Foundation) to `Sendable` across module boundaries — Swift 6 strict concurrency rejects this. Local Xcode 16.4+ is permissive; CI's Xcode 16.2 enforces. Standard fix: `extension UserDefaults: @unchecked Sendable, UserDefaultsStorage` (UserDefaults is documented as thread-safe).

Without this fix, HyzerKit doesn't even build on CI, and `HyzerApp ViewModel Tests` is `needs: hyzerkit-tests` — so it skips, doubly silent.

## Impact assessment

Surfaced during PR #94 (Story 15.2) root-cause analysis. **Six of the eight Epic 15 Wave 1 PRs merged on 2026-05-19** (#101, #99, #98, #97, #100, #95, #96) had BOTH test checks reporting green despite HyzerKit failing to build AND xcodebuild failing on the iOS 18.2 destination issue:

> `xcodebuild: error: Unable to find a destination matching the provided destination specifier ... iOS 18.2 is not installed.`

## Expected CI behavior after merge

- **HyzerKit Tests (swift test):** Will pass again. The Sendable fix removes the build blocker; the suite has 428 tests with 1 known `WatchVoiceViewModel.auto-commit timer` flake (Story 15.8 territory) that may or may not surface on CI under load.
- **HyzerApp ViewModel Tests (xcodebuild):** Will **fail** correctly on every PR touching HyzerApp until the iOS-18.2 environmental gap is closed. Three remediation paths in Story 15.2 spec "Pending Handoff":
  1. Install iOS 18.2 simulator runtime on local + CI runners
  2. Downgrade build target to a shipped iOS version
  3. Wait for runner-image refresh

## Commits

- `805c815` — `fix(ci): add `set -o pipefail` to xcodebuild + swift test steps`
- `de7e44a` — `fix(concurrency): mark UserDefaults @unchecked Sendable for Swift 6 strict conformance`

## Test plan

- [ ] HyzerKit Tests (swift test) passes on this PR
- [ ] HyzerApp ViewModel Tests (xcodebuild) fails on this PR (correct — env gap)
- [ ] After merge: next PR touching HyzerApp shows red xcodebuild check (until env fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)