### PR TITLE
fix(concurrency): silence retroactive-conformance warning on UserDefaults Sendable

### DIFF
--- a/HyzerKit/Sources/HyzerKit/Sync/UserDefaultsStorage.swift
+++ b/HyzerKit/Sources/HyzerKit/Sync/UserDefaultsStorage.swift
@@ -13,7 +13,15 @@ public protocol UserDefaultsStorage: Sendable {
 // concurrency requires retroactive `Sendable` conformance on cross-module
 // classes to be opt-in via `@unchecked Sendable`. `UserDefaults` is
 // documented as thread-safe by Apple, so the unchecked opt-in is sound.
-extension UserDefaults: @unchecked Sendable, UserDefaultsStorage {
+//
+// `@retroactive` (Swift 5.10+ / SE-0364) explicitly acknowledges the
+// cross-module retroactive conformance and silences the future-proofing
+// warning: "Extension declares a conformance of imported type 'UserDefaults'
+// to imported protocol 'Sendable'; this will not behave correctly if the
+// owners of 'Foundation' introduce this conformance in the future."
+extension UserDefaults: @retroactive @unchecked Sendable {}
+
+extension UserDefaults: UserDefaultsStorage {
     public func setString(_ value: String, forKey defaultName: String) {
         set(value, forKey: defaultName)
     }


### PR DESCRIPTION
## Summary

PR #102's `@unchecked Sendable` conformance on `UserDefaults` fixed the build error under Swift 6 strict concurrency, but Swift 5.10+ emits a future-proofing warning at every consumer (HyzerApp and HyzerAppTests both see it once = the 2-place report):

> warning: Extension declares a conformance of imported type 'UserDefaults' to imported protocol 'Sendable'; this will not behave correctly if the owners of 'Foundation' introduce this conformance in the future

## Fix

Apply the `@retroactive` attribute (SE-0364, Swift 5.10+) which explicitly acknowledges intentional cross-module retroactive conformance and silences the warning. Split the conformances into two extensions for clarity — `UserDefaultsStorage` is in this module so its extension is not retroactive; only the `Sendable` extension is.

```swift
extension UserDefaults: @retroactive @unchecked Sendable {}

extension UserDefaults: UserDefaultsStorage {
    public func setString(_ value: String, forKey defaultName: String) {
        set(value, forKey: defaultName)
    }
}
```

## Test plan

- [x] `swift test --package-path HyzerKit` passes (428 tests, same pre-existing `WatchVoiceViewModel` flake — no behavior change)
- [x] Warning gone from local build output
- [ ] CI confirms HyzerKit + SwiftLint stay green (xcodebuild check remains red due to the separate layer-6 bootstrap-crash tracked in `deferred-work.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)